### PR TITLE
 Fix includes(va).references(va) in rails 5.1

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -195,8 +195,9 @@ module ActiveRecord
         # when 5.0 support is dropped, assume a block given
         if block_given?
           yield recs, join_dep
+        else
+          recs
         end
-        recs
       end
 
       # From ActiveRecord::QueryMethods

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -187,7 +187,10 @@ module ActiveRecord
         else
           recs = real.find_with_associations
         end
-        MiqPreloader.preload(recs, preload_values + includes_values) if includes_values
+
+        if includes_values
+          ActiveRecord::Associations::Preloader.new.preload(recs, preload_values + includes_values)
+        end
 
         # when 5.0 support is dropped, assume a block given
         if block_given?

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -983,4 +983,13 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
     tc.save
     expect(tc.attributes.size).to eq(2)
   end
+
+  it "doesn't botch up the attributes with includes.references", :with_test_class do
+    TestClass.virtual_attribute :vattr, :string
+    TestClass.create(:str => "abc", :col1 => 55)
+
+    tc = TestClass.includes(:vattr).references(:vattr).first
+
+    expect(tc.attributes.keys).to match_array(%w(id str col1))
+  end
 end


### PR DESCRIPTION
In rails 5.1, it was not properly aliasing the names of columns
after an `includes().references()`

The attributes were coming across as the alias name instead of the attribute name