### PR TITLE
Support legacy types for attributes

### DIFF
--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -141,3 +141,12 @@ end
 
 require "active_record/virtual_attributes/virtual_total"
 require "active_record/virtual_attributes/arel_groups"
+
+# legacy support for sql types
+module VirtualAttributes
+  module Type
+    Symbol      = ActiveRecord::VirtualAttributes::Type::Symbol
+    StringSet   = ActiveRecord::VirtualAttributes::Type::StringSet
+    NumericSet  = ActiveRecord::VirtualAttributes::Type::NumericSet
+  end
+end


### PR DESCRIPTION
This PR adds support for the data types used by previous versions of this extension.f

Some parts of the app are throwing errors when deserializing yaml from the database:

```
ArgumentError: undefined class/module VirtualAttributes::Type::
```

This happens because a data type was stored in yaml. Those values have changed and the existing one can't be found anymore

/cc @mzazrivec This should solve your problem