### PR TITLE
[WIP] Null when no associated records (fix sorting)

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -81,11 +81,10 @@ module VirtualAttributes
             else
               rel = send(relation)
               if rel.loaded?
-                rel.blank? ? nil : rel.map { |t| t.send(column) }.compact.send(method_name)
+                rel_values = rel.map { |t| t.send(column) }.compact
+                rel_values.blank? ? nil : rel_values.send(method_name)
               else
-                # virtual attributes support for aggregates
-                arel_column = rel.klass.arel_attribute(column)
-                rel.try(method_name, arel_column) || 0
+                rel.try(method_name, rel.klass.arel_attribute(column))
               end
             end
           end

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -80,7 +80,7 @@ module VirtualAttributes
               begin
                 rel = send(relation)
                 if rel.loaded?
-                  rel.blank? ? nil : (rel.map { |t| t.send(column).to_i } || 0).send(method_name)
+                  rel.blank? ? nil : rel.map { |t| t.send(column) }.compact.send(method_name)
                 else
                   # aggregates are not smart enough to handle virtual attributes
                   arel_column = rel.klass.arel_attribute(column)

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -405,15 +405,15 @@ describe VirtualAttributes::VirtualTotal do
         authors
         query = Author.select(:id, :sum_recently_published_books_rating).order(:id).load
         expect do
-          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-        end.to match_query_limit_of(2)
+          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, nil])
+        end.to match_query_limit_of(0)
       end
 
       it "calculates sum from attribute (and preloaded association)" do
         authors
         query = Author.includes(:recently_published_books).select(:id, :sum_recently_published_books_rating).order(:id).load
         expect do
-          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, 0])
+          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, nil])
         end.to match_query_limit_of(0)
       end
     end

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -397,7 +397,7 @@ describe VirtualAttributes::VirtualTotal do
         authors.each { |a| a.recently_published_books.load }
 
         expect do
-          expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, 0])
+          expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, nil])
         end.to match_query_limit_of(0)
       end
 


### PR DESCRIPTION
extracted:

- [x] #14 extracting tests - lots of the things floating around assume the tests are there.

for attributes with null values, doesn't go back to the database multiple times

for aggregates (currently only really use `sum`) - it returns 0

so when you sort by aggregates, the 0's (which are null behind the sceens) sort properly

this fixes an issue with #8 