### PR TITLE
Add tests for virtual totals

### DIFF
--- a/spec/support/match_query_limit_of.rb
+++ b/spec/support/match_query_limit_of.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :match_query_limit_of do |expected|
   end
 
   failure_message do |_actual|
-    "Expected #{expected} queries, got #{@query_count}"
+    "Expected #{expected} queries, got #{@counter.query_count}"
   end
 
   description do


### PR DESCRIPTION
need these tests to address more edge cases

if you notice, the same attribute for the same models are returning different values depending upon what is preloaded.

This set of tests document the current behavior, so future code changes can make the behavior changes more obvious (as they work to getting the same values regardless of the loaded values)