### PR TITLE
Zero when no associated records (fix sorting)

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -42,7 +42,7 @@ module VirtualAttributes
       #
       #    def allocated_disk_storage
       #      if disks.loaded?
-      #        disks.blank? ? nil : disks.map(&:size).compact.sum
+      #        disks.map(&:size).compact.sum
       #      else
       #        disks.sum(:size) || 0
       #      end
@@ -88,7 +88,7 @@ module VirtualAttributes
           if has_attribute?(name)
             self[name] || 0
           elsif (rel = send(relation)).loaded?
-            rel.blank? ? nil : rel.map { |t| t.send(column) }.compact.send(method_name)
+            rel.map { |t| t.send(column) }.compact.send(method_name)
           else
             rel.try(method_name, column) || 0
           end

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -128,7 +128,9 @@ module VirtualAttributes
                  end
 
           # add () around query
-          t.grouping(Arel::Nodes::SqlLiteral.new(sql))
+          query = t.grouping(Arel::Nodes::SqlLiteral.new(sql))
+          # add coalesce to ensure correct value comes out
+          t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [query, Arel::Nodes::SqlLiteral.new("0")]))
         end
       end
     end

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -85,8 +85,8 @@ module VirtualAttributes
 
       def define_virtual_aggregate_method(name, relation, method_name, column)
         define_method(name) do
-          if attribute_present?(name)
-            self[name]
+          if has_attribute?(name)
+            self[name] || 0
           elsif (rel = send(relation)).loaded?
             rel.blank? ? nil : rel.map { |t| t.send(column) }.compact.send(method_name)
           else

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -457,14 +457,14 @@ RSpec.describe VirtualAttributes::VirtualTotal do
         query = Author.select(:id, :sum_recently_published_books_rating).order(:id).load
         expect do
           expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-        end.to make_database_queries(:count => 2)
+        end.to make_database_queries(:count => 0)
       end
 
       it "calculates sum from attribute (and preloaded association)" do
         authors
         query = Author.includes(:recently_published_books).select(:id, :sum_recently_published_books_rating).order(:id).load
         expect do
-          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, 0])
+          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
         end.to_not make_database_queries
       end
     end

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
         authors.each { |a| a.recently_published_books.load }
 
         expect do
-          expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, 0])
+          expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
         end.to_not make_database_queries
       end
 

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -467,6 +467,12 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
         end.to_not make_database_queries
       end
+
+      it "orders by values with a nil (having the nil (defaulted to 0) first" do
+        authors
+        query = Author.order(:sum_recently_published_books_rating)
+        expect(query.map(&:id)).to eq([author3, author4, author2, author].map(&:id))
+      end
     end
   end
 end


### PR DESCRIPTION
Depends:

- [x] #31 refactor virtual_totals
- [x] #54 refactor virtual_totals

## Overview

`virtual_aggregate` allows us to define a `sum(column)` up front and assign it to a `virtual_attribute`.

This means we define a virtual attribute as an aggregate of a relation, without defining any ruby or sql.

So `Author.total_ratings` the same as `author.books.sum(:ratings)`

## Problem

Calculating the sum of a column when there are no records is surprisingly not straight forward.

ActiveRecord and ruby treat the sum of no rows as 0. While SQL treats it as `null` (`nil` in ruby terms)

## Samples

```ruby
author = Author.create
author.books.size # => 0
author.books.sum(:rating) # => 0

[].sum # => 0
```

```sql
SELECT sum(ratings) AS sum FROM authors;

sum
---
null
```

## Before

There are a few methods for calculating the sum from an association:

- a one off database query
- a relation that is loaded in memory
- an attribute form a `SELECT` clause.

Unfortunately, our code is not consistent on the return values based upon how the data is retrieved:

```ruby
author = Author.create

author.books.total_rating # => 0
author.books.load.total_ratings # => nil
Author.select(:total_ratings).first.total_rating # => nil
```

## After

```ruby
author = Author.create

author.books.total_rating # => 0
author.books.load.total_ratings # => 0
Author.select(:total_ratings).first.total_rating # => 0
```

## Alternative

While I wanted to return `nil` for this value (see #13), I realize that rails really wants the sum to be 0. A few default values (i.e.: `|| 0`) in the internals of active record's `count` make it difficult to change this value. And I don't think we want to change the internals of rails like this.

This PR makes the `virtual_aggregate` return a consistent 0 when summing no records from the database.
