### PR TITLE
Support rails 5.1 for preloading values

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -30,20 +30,28 @@ module ActiveRecord
           virtual_attribute?(name) || virtual_reflection?(name)
         end
 
-        def remove_virtual_fields(associations)
+        def replace_virtual_fields(associations)
           return associations if associations.blank?
 
           case associations
           when String, Symbol
-            virtual_field?(associations) ? nil : associations
+            virtual_field?(associations) ? replace_virtual_fields(virtual_includes(associations)) : associations
           when Array
-            associations.collect { |association| remove_virtual_fields(association) }.compact
+            associations.collect { |association| replace_virtual_fields(association) }.compact
           when Hash
             associations.each_with_object({}) do |(parent, child), h|
               if virtual_field?(parent) # form virtual_attribute => {}
+                case (new_includes = replace_virtual_fields(virtual_includes(parent)))
+                when String, Symbol
+                  h[new_includes] = {}
+                when Array
+                  new_includes.each { |association| h[association] = {} }
+                when Hash
+                  h.deep_merge!(new_includes)
+                end
               else
                 reflection = reflect_on_association(parent.to_sym)
-                h[parent] = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.remove_virtual_fields(child) || {}
+                h[parent] = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.replace_virtual_fields(child) || {}
               end
             end
           else
@@ -172,7 +180,7 @@ module ActiveRecord
 
   class Relation
     def without_virtual_includes
-      filtered_includes = includes_values && klass.remove_virtual_fields(includes_values)
+      filtered_includes = includes_values && klass.replace_virtual_fields(includes_values)
       if filtered_includes != includes_values
         spawn.tap { |other| other.includes_values = filtered_includes }
       else
@@ -182,25 +190,12 @@ module ActiveRecord
 
     include(Module.new {
       # From ActiveRecord::FinderMethods
-      def find_with_associations
+      def find_with_associations(&block)
         real = without_virtual_includes
-        return super if real.equal?(self)
-
-        if ActiveRecord.version.to_s >= "5.1"
-          recs, join_dep = real.find_with_associations { |relation, join_dependency| [relation, join_dependency] }
+        if real.equal?(self)
+          super
         else
-          recs = real.find_with_associations
-        end
-
-        if includes_values
-          ActiveRecord::Associations::Preloader.new.preload(recs, preload_values + includes_values)
-        end
-
-        # when 5.0 support is dropped, assume a block given
-        if block_given?
-          yield recs, join_dep
-        else
-          recs
+          real.find_with_associations(&block)
         end
       end
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -31,6 +31,8 @@ module ActiveRecord
         end
 
         def remove_virtual_fields(associations)
+          return associations if associations.blank?
+
           case associations
           when String, Symbol
             virtual_field?(associations) ? nil : associations
@@ -38,9 +40,11 @@ module ActiveRecord
             associations.collect { |association| remove_virtual_fields(association) }.compact
           when Hash
             associations.each_with_object({}) do |(parent, child), h|
-              next if virtual_field?(parent)
-              reflection = reflect_on_association(parent.to_sym)
-              h[parent] = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.remove_virtual_fields(child) || {}
+              if virtual_field?(parent) # form virtual_attribute => {}
+              else
+                reflection = reflect_on_association(parent.to_sym)
+                h[parent] = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.remove_virtual_fields(child) || {}
+              end
             end
           else
             associations

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -122,13 +122,13 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(TestClass.remove_virtual_fields(:vcol1)).to          be_nil
-          expect(TestClass.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(TestClass.remove_virtual_fields([:vcol1])).to eq([])
-          expect(TestClass.remove_virtual_fields([:vcol1, :ref1])).to eq([:ref1])
-          expect(TestClass.remove_virtual_fields(:vcol1 => {})).to eq({})
-          expect(TestClass.remove_virtual_fields(:vcol1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(TestClass.replace_virtual_fields(:vcol1)).to be_nil
+          expect(TestClass.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(TestClass.replace_virtual_fields([:vcol1])).to eq([])
+          expect(TestClass.replace_virtual_fields([:vcol1, :ref1])).to eq([:ref1])
+          expect(TestClass.replace_virtual_fields(:vcol1 => {})).to eq({})
+          expect(TestClass.replace_virtual_fields(:vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end
@@ -155,16 +155,16 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(test_sub_class.remove_virtual_fields(:vcol1)).to             be_nil
-          expect(test_sub_class.remove_virtual_fields(:vcolsub1)).to          be_nil
-          expect(test_sub_class.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(test_sub_class.remove_virtual_fields([:vcol1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vcolsub1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
-          expect(test_sub_class.remove_virtual_fields({:vcol1    => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields({:vcolsub1 => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
+        it ".replace_virtual_fields" do
+          expect(test_sub_class.replace_virtual_fields(:vcol1)).to             be_nil
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1)).to          be_nil
+          expect(test_sub_class.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(test_sub_class.replace_virtual_fields([:vcol1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vcolsub1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
+          expect(test_sub_class.replace_virtual_fields(:vcol1    => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1 => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end
@@ -336,13 +336,13 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(TestClass.remove_virtual_fields(:vref1)).to          be_nil
-          expect(TestClass.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(TestClass.remove_virtual_fields([:vref1])).to eq([])
-          expect(TestClass.remove_virtual_fields([:vref1, :ref1])).to eq([:ref1])
-          expect(TestClass.remove_virtual_fields(:vref1 => {})).to eq({})
-          expect(TestClass.remove_virtual_fields(:vref1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(TestClass.replace_virtual_fields(:vref1)).to be_nil
+          expect(TestClass.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(TestClass.replace_virtual_fields([:vref1])).to eq([])
+          expect(TestClass.replace_virtual_fields([:vref1, :ref1])).to eq([:ref1])
+          expect(TestClass.replace_virtual_fields(:vref1 => {})).to eq({})
+          expect(TestClass.replace_virtual_fields(:vref1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end
@@ -371,16 +371,16 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(test_sub_class.remove_virtual_fields(:vref1)).to             be_nil
-          expect(test_sub_class.remove_virtual_fields(:vrefsub1)).to          be_nil
-          expect(test_sub_class.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(test_sub_class.remove_virtual_fields([:vref1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vrefsub1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vrefsub1, :vref1, :ref1])).to eq([:ref1])
-          expect(test_sub_class.remove_virtual_fields({:vref1    => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields({:vrefsub1 => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields(:vrefsub1 => {}, :vref1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(test_sub_class.replace_virtual_fields(:vref1)).to be_nil
+          expect(test_sub_class.replace_virtual_fields(:vrefsub1)).to be_nil
+          expect(test_sub_class.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(test_sub_class.replace_virtual_fields([:vref1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vrefsub1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vrefsub1, :vref1, :ref1])).to eq([:ref1])
+          expect(test_sub_class.replace_virtual_fields(:vref1 => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vrefsub1 => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vrefsub1 => {}, :vref1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -95,42 +95,36 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "preloads virtual_attribute (:uses => :book)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:first_book_name).references(:first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes([:first_book_name]).references(:first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes(:first_book_name => {}).references(:first_book_name => {})).to preload_values(:first_book_name, book_name)
     end
 
     it "preloads virtual_attribute (delegate defines :uses => :author)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Book.includes(:author_name).references(:author_name => {})).to preload_values(:author_name, author_name)
       expect(Book.includes([:author_name]).references(:author_name => {})).to preload_values(:author_name, author_name)
       expect(Book.includes(:author_name => {}).references(:author_name => {})).to preload_values(:author_name, author_name)
     end
 
     it "preloads virtual_attribute (:uses => :upper_author_name) (:uses => :author_name)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Book.includes(:upper_author_name_def).references(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
       expect(Book.includes([:upper_author_name_def]).references(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
       expect(Book.includes(:upper_author_name_def => {}).references(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
     end
 
     it "preloads virtual_attribute (multiple)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:nick_or_name).includes(:first_book_name).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes([:nick_or_name, :first_book_name]).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes(:nick_or_name => {}, :first_book_name => {}).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
     end
 
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:first_book_author_name).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes([:first_book_author_name]).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:first_book_author_name => {}).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "preloads virtual_attributes (:uses => {:first_book_author_name}) which (:uses => {:books => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       ref = {:first_book_author_name => {}}
       expect(Author.includes(:upper_first_book_author_name).references(ref)).to preload_values(:upper_first_book_author_name, author_name.upcase)
       expect(Author.includes([:upper_first_book_author_name]).references(ref)).to preload_values(:upper_first_book_author_name, author_name.upcase)
@@ -144,7 +138,6 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "uses included associations" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => [:author]).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author => {}}).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
@@ -155,14 +148,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "uses included fields" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "uses preloaded fields" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
@@ -181,13 +172,11 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
   context "preloads virtual_attribute with select.includes.references" do
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Book.select(:author_name).includes(:author_name).references(:author_name)).to preload_values(:author_name, author_name)
     end
   end
 
   it "preloads virtual_attribute in :include when :conditions are also present in calculations" do
-    skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.name = '#{author_name}'")).to preload_values(:author_name, author_name)
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.id IS NOT NULL")).to preload_values(:author_name, author_name)
   end
@@ -222,21 +211,18 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
   context "preloads virtual_reflection with includes.references" do
     it "preloads virtual_reflection (:uses => [:books])" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:named_books).references(:named_books => {})).to preload_values(:named_books, named_books)
       expect(Author.includes([:named_books]).references(:named_books => {})).to preload_values(:named_books, named_books)
       expect(Author.includes(:named_books => {}).references(:named_books => {})).to preload_values(:named_books, named_books)
     end
 
     it "preloads virtual_reflection (:uses => {:books => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books_with_authors).references(:books_with_authors => {})).to preload_values(:books_with_authors, named_books)
       expect(Author.includes([:books_with_authors]).references(:books_with_authors => {})).to preload_values(:books_with_authors, named_books)
       expect(Author.includes(:books_with_authors => {}).references(:books_with_authors => {})).to preload_values(:books_with_authors, named_books)
     end
 
     it "preloads virtual_reflection(:uses => :books => :bookmarks) (nothing virtual)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       bookmarked_book = Author.first.books.first
       expect(Author.includes(:book_with_most_bookmarks).references(:book_with_most_bookmarks)).to preload_values(:book_with_most_bookmarks, bookmarked_book)
     end


### PR DESCRIPTION
the way `eager_loading` is handled changes over the rails versions.
It looks like virtual attributes only handles 5.0, and not quite up to snuff with 5.1 (or 5.2)

This brings the eager loading up to par.

This also fixes a bug dealing with includes() passing in array.

/cc @jrafanie this is the issue you were seeing with 5.1 migration
