### PR TITLE
[WIP] require types defined

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -143,9 +143,14 @@ module ActiveRecord
         #   See select_from_alias for examples
 
         def virtual_delegate_arel(col, to_ref)
-          # ensure the column has sql and the association is reachable via sql
+          # Ensure the association is reachable via sql
+          #
+          # But NOT ensuring the target column has sql
+          #   to_ref.klass.arel_attribute(col) loads the target classes' schema.
+          #   This cascades and causing a race condition
+          #
           # There is currently no way to propagate sql over a virtual association
-          if to_ref.klass.arel_attribute(col) && reflect_on_association(to_ref.name)
+          if reflect_on_association(to_ref.name)
             if to_ref.macro == :has_one || to_ref.macro == :belongs_to
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               lambda do |t|
@@ -248,6 +253,7 @@ module ActiveRecord
         to_table    = select_from_alias_table(to_ref.klass, src_model_id.relation)
         to_model_id = to_ref.klass.arel_attribute(to_model_col_name, to_table)
         to_column   = to_ref.klass.arel_attribute(col, to_table)
+        raise "invalid virtual delegate referencing #{to_ref.name}.#{col}" unless to_column
         arel        = query.except(:select).select(to_column).arel
                            .from(to_table)
                            .where(to_model_id.eq(src_model_id))

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -72,7 +72,7 @@ module ActiveRecord
           end
 
           col = col.to_s
-          type = options[:type] || to_ref.klass.type_for_attribute(col)
+          type = options[:type]
           type = ActiveRecord::Type.lookup(type) if type.kind_of?(Symbol)
           raise "unknown attribute #{to}##{col} referenced in #{name}" unless type
           arel = virtual_delegate_arel(col, to_ref)

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -152,11 +152,11 @@ module ActiveRecord
           # There is currently no way to propagate sql over a virtual association
           if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
             lambda do |t|
-              if ActiveRecord.version.to_s >= "5.1"
-                join_keys = to_ref.join_keys
-              else
-                join_keys = to_ref.join_keys(to_ref.klass)
-              end
+              join_keys = if ActiveRecord.version.to_s >= "5.1"
+                            to_ref.join_keys
+                          else
+                            to_ref.join_keys(to_ref.klass)
+                          end
               src_model_id = arel_attribute(join_keys.foreign_key, t)
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -72,7 +72,8 @@ module ActiveRecord
           end
 
           col = col.to_s
-          type = to_ref.klass.type_for_attribute(col)
+          type = options[:type] || to_ref.klass.type_for_attribute(col)
+          type = ActiveRecord::Type.lookup(type) if type.kind_of?(Symbol)
           raise "unknown attribute #{to}##{col} referenced in #{name}" unless type
           arel = virtual_delegate_arel(col, to_ref)
           define_virtual_attribute(method_name, type, :uses => (options[:uses] || to), :arel => arel)

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -151,7 +151,6 @@ module ActiveRecord
           #
           # There is currently no way to propagate sql over a virtual association
           if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
-            blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
             lambda do |t|
               if ActiveRecord.version.to_s >= "5.1"
                 join_keys = to_ref.join_keys
@@ -159,6 +158,7 @@ module ActiveRecord
                 join_keys = to_ref.join_keys(to_ref.klass)
               end
               src_model_id = arel_attribute(join_keys.foreign_key, t)
+              blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
             end
           end

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -150,18 +150,16 @@ module ActiveRecord
           #   This cascades and causing a race condition
           #
           # There is currently no way to propagate sql over a virtual association
-          if reflect_on_association(to_ref.name)
-            if to_ref.macro == :has_one || to_ref.macro == :belongs_to
-              blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
-              lambda do |t|
-                if ActiveRecord.version.to_s >= "5.1"
-                  join_keys = to_ref.join_keys
-                else
-                  join_keys = to_ref.join_keys(to_ref.klass)
-                end
-                src_model_id = arel_attribute(join_keys.foreign_key, t)
-                VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
+          if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
+            blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
+            lambda do |t|
+              if ActiveRecord.version.to_s >= "5.1"
+                join_keys = to_ref.join_keys
+              else
+                join_keys = to_ref.join_keys(to_ref.klass)
               end
+              src_model_id = arel_attribute(join_keys.foreign_key, t)
+              VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
             end
           end
         end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -63,7 +63,7 @@ class Book < VitualTotalTestBase
   scope :published, -> { where(:published => true)  }
   scope :wip,       -> { where(:published => false) }
 
-  virtual_delegate :name, :to => :author, :prefix => true
+  virtual_delegate :name, :to => :author, :prefix => true, :type => :string
 
   def self.create_with_bookmarks(count)
     Author.create(:name => "foo").books.create!(:name => "book").tap { |book| book.create_bookmarks(count) }

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -667,6 +667,21 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         end
       end
 
+      it "doesn't reference target class when :type is specified" do
+        model = Class.new(TestClassBase) do
+          self.table_name = 'test_classes'
+          def self.name
+            "AnonymousType"
+          end
+          has_many :others, :class_name => "InvalidType"
+          virtual_delegate :col4, :to => :others, :type => :integer
+        end
+        # doesn't lookup InvalidType class with this model
+        expect { model.new }.not_to raise_error
+        # referencing the relation still accesses the model (which is invalid so blows up)
+        expect { model.new.col4 }.to raise_error(NameError)
+      end
+
       it "catches invalid references" do
         expect do
           Class.new(TestClassBase) do

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -645,6 +645,9 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
           tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x"))
           expect(tcs.map(&:x)).to match_array([nil, 99])
+
+          expect { tcs = TestOtherClass.all.select(:id, :ocol1, :col1).load }.to match_query_limit_of(1)
+          expect(tcs.map(&:col1)).to match_array([nil, 99])
         end
 
         # this may fail in the future as our way of building queries may change
@@ -654,6 +657,23 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           sql = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x")).to_sql
           expect(sql).to match(/["`]test_classes["`].["`]col1["`]/i)
         end
+
+        it "supports :type (and works when reference IS valid)" do
+          TestOtherClass.virtual_delegate :col1, :to => :oref1, :type => :integer
+          TestOtherClass.create(:oref1 => TestClass.create)
+          TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
+          tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x"))
+          expect(tcs.map(&:x)).to match_array([nil, 99])
+        end
+      end
+
+      it "catches invalid references" do
+        expect do
+          Class.new(TestClassBase) do
+            self.table_name = 'test_classes'
+            virtual_delegate :col4, :to => :others, :type => :integer
+          end.new
+        end.to raise_error
       end
     end
 

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -476,7 +476,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
       end
 
       it "supports delegates" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
       end
@@ -497,24 +497,24 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
       let(:parent) { TestClass.create(:col1 => 4) }
 
       it "delegates to parent" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         tc = TestClass.new(:ref1 => parent)
         expect(tc.parent_col1).to eq(4)
       end
 
       it "delegates to nil parent" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to be_nil
       end
 
       it "defines parent virtual attribute" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         expect(TestClass.virtual_attribute_names).to include("parent_col1")
       end
 
       it "delegates to parent (sql)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         TestClass.create(:ref1 => parent)
         tcs = TestClass.all.select(:id, :col1, TestClass.arel_attribute(:parent_col1).as("x"))
         expect(tcs.map(&:x)).to match_array([nil, 4])
@@ -528,24 +528,24 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         let(:child) { TestClass.create }
 
         it "delegates to child" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :type => :integer
           tc = TestClass.create(:ref2 => child)
           expect(tc.child_col1).to eq(tc.id)
         end
 
         it "delegates to nil child" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :allow_nil => true
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :allow_nil => true, :type => :integer
           tc = TestClass.new
           expect(tc.child_col1).to be_nil
         end
 
         it "defines child virtual attribute" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :type => :integer
           expect(TestClass.virtual_attribute_names).to include("child_col1")
         end
 
         it "delegates to child (sql)" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :type => :integer
           tc = TestClass.create(:ref2 => child)
           tcs = TestClass.all.select(:id, :col1, :child_col1).to_a
           expect { expect(tcs.map(&:child_col1)).to match_array([nil, tc.id]) }.to match_query_limit_of(0)
@@ -554,7 +554,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         # this may fail in the future as our way of building queries may change
         # just want to make sure it changed due to intentional changes
         it "uses table alias for subquery" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :type => :integer
           sql = TestClass.all.select(:id, :col1, :child_col1).to_sql
           expect(sql).to match(/["`]test_classes_[^"`]*["`][.]["`]col1["`]/i)
         end
@@ -570,7 +570,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         # ensure virtual attribute referencing a relation with a select()
         # does not throw an exception due to multi-column select
         it "properly generates sub select" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :type => :integer
           TestClass.create(:ref2 => child)
           expect { TestClass.all.select(:id, :child_col1).to_a }.to_not raise_error
         end
@@ -587,7 +587,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         # ensure virtual attribute referencing a relation with a select()
         # does not throw an exception due to multi-column select
         it "properly generates sub select" do
-          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
+          TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2, :type => :integer
           TestClass.create(:ref2 => child)
           expect { TestClass.all.select(:id, :child_col1).to_a }.to_not raise_error
         end
@@ -605,7 +605,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
           # TODO: -> { order(:col1) }
           TestClass.has_one :child, :class_name => 'TestOtherClass', :foreign_key => :ocol1
-          TestClass.virtual_delegate :child_str, :to => "child.ostr"
+          TestClass.virtual_delegate :child_str, :to => "child.ostr", :type => :string
         end
 
         after do
@@ -640,7 +640,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         end
 
         it "delegates to another table" do
-          TestOtherClass.virtual_delegate :col1, :to => :oref1
+          TestOtherClass.virtual_delegate :col1, :to => :oref1, :type => :integer
           TestOtherClass.create(:oref1 => TestClass.create)
           TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
           tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x"))
@@ -653,7 +653,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
         # this may fail in the future as our way of building queries may change
         # just want to make sure it changed due to intentional changes
         it "delegates to another table without alias" do
-          TestOtherClass.virtual_delegate :col1, :to => :oref1
+          TestOtherClass.virtual_delegate :col1, :to => :oref1, :type => :integer
           sql = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x")).to_sql
           expect(sql).to match(/["`]test_classes["`].["`]col1["`]/i)
         end
@@ -724,7 +724,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
       end
 
       it "supports delegates" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
       end
@@ -822,42 +822,42 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
       let(:parent) { TestClass.create(:col1 => 4) }
 
       it "delegates to child" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         tc = TestClass.new(:ref1 => parent)
         expect(tc.parent_col1).to eq(4)
       end
 
       it "delegates to nil child" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to be_nil
       end
 
       it "defines virtual attribute" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         expect(TestClass.virtual_attribute_names).to include("parent_col1")
       end
 
       it "defines with a new name" do
-        TestClass.virtual_delegate 'funky_name', :to => "ref1.col1"
+        TestClass.virtual_delegate 'funky_name', :to => "ref1.col1", :type => :string
         tc = TestClass.new(:ref1 => parent)
         expect(tc.funky_name).to eq(4)
       end
 
       it "defaults for to nil child (array)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => []
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => [], :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to eq([])
       end
 
       it "defaults for to nil child (integer)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => 0
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => 0, :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to eq(0)
       end
 
       it "defaults for to nil child (string)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => "def"
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => "def", :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to eq("def")
       end


### PR DESCRIPTION
running into deadlocks with this.

The referenced schema (and class) need to be loaded for this class to be fully defined.

Unfortunately, that then requires that the other foreign classes also be loaded.

This is causing race conditions with the locks around loading classes.

One option is to punt on the type discovery. Which is really a shame, but it remove the deadlocks