### PR TITLE
Allow virtual delegate to be specified or discovered

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -152,11 +152,11 @@ module ActiveRecord
           # There is currently no way to propagate sql over a virtual association
           if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
             lambda do |t|
-              if ActiveRecord.version.to_s >= "5.1"
-                join_keys = to_ref.join_keys
-              else
-                join_keys = to_ref.join_keys(to_ref.klass)
-              end
+              join_keys = if ActiveRecord.version.to_s >= "5.1"
+                            to_ref.join_keys
+                          else
+                            to_ref.join_keys(to_ref.klass)
+                          end
               src_model_id = arel_attribute(join_keys.foreign_key, t)
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -72,7 +72,8 @@ module ActiveRecord
           end
 
           col = col.to_s
-          type = to_ref.klass.type_for_attribute(col)
+          type = options[:type] || to_ref.klass.type_for_attribute(col)
+          type = ActiveRecord::Type.lookup(type) if type.kind_of?(Symbol)
           raise "unknown attribute #{to}##{col} referenced in #{name}" unless type
           arel = virtual_delegate_arel(col, to_ref)
           define_virtual_attribute(method_name, type, :uses => (options[:uses] || to), :arel => arel)

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -151,7 +151,6 @@ module ActiveRecord
           #
           # There is currently no way to propagate sql over a virtual association
           if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
-            blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
             lambda do |t|
               if ActiveRecord.version.to_s >= "5.1"
                 join_keys = to_ref.join_keys
@@ -159,6 +158,7 @@ module ActiveRecord
                 join_keys = to_ref.join_keys(to_ref.klass)
               end
               src_model_id = arel_attribute(join_keys.foreign_key, t)
+              blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
             end
           end

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -150,18 +150,16 @@ module ActiveRecord
           #   This cascades and causing a race condition
           #
           # There is currently no way to propagate sql over a virtual association
-          if reflect_on_association(to_ref.name)
-            if to_ref.macro == :has_one || to_ref.macro == :belongs_to
-              blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
-              lambda do |t|
-                if ActiveRecord.version.to_s >= "5.1"
-                  join_keys = to_ref.join_keys
-                else
-                  join_keys = to_ref.join_keys(to_ref.klass)
-                end
-                src_model_id = arel_attribute(join_keys.foreign_key, t)
-                VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
+          if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
+            blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
+            lambda do |t|
+              if ActiveRecord.version.to_s >= "5.1"
+                join_keys = to_ref.join_keys
+              else
+                join_keys = to_ref.join_keys(to_ref.klass)
               end
+              src_model_id = arel_attribute(join_keys.foreign_key, t)
+              VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
             end
           end
         end

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -143,9 +143,14 @@ module ActiveRecord
         #   See select_from_alias for examples
 
         def virtual_delegate_arel(col, to_ref)
-          # ensure the column has sql and the association is reachable via sql
+          # Ensure the association is reachable via sql
+          #
+          # But NOT ensuring the target column has sql
+          #   to_ref.klass.arel_attribute(col) loads the target classes' schema.
+          #   This cascades and causing a race condition
+          #
           # There is currently no way to propagate sql over a virtual association
-          if to_ref.klass.arel_attribute(col) && reflect_on_association(to_ref.name)
+          if reflect_on_association(to_ref.name)
             if to_ref.macro == :has_one || to_ref.macro == :belongs_to
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               lambda do |t|

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -645,6 +645,9 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
           tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x"))
           expect(tcs.map(&:x)).to match_array([nil, 99])
+
+          expect { tcs = TestOtherClass.all.select(:id, :ocol1, :col1).load }.to match_query_limit_of(1)
+          expect(tcs.map(&:col1)).to match_array([nil, 99])
         end
 
         # this may fail in the future as our way of building queries may change
@@ -654,6 +657,23 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           sql = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x")).to_sql
           expect(sql).to match(/["`]test_classes["`].["`]col1["`]/i)
         end
+
+        it "supports :type (and works when reference IS valid)" do
+          TestOtherClass.virtual_delegate :col1, :to => :oref1, :type => :integer
+          TestOtherClass.create(:oref1 => TestClass.create)
+          TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
+          tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_attribute(:col1).as("x"))
+          expect(tcs.map(&:x)).to match_array([nil, 99])
+        end
+      end
+
+      it "catches invalid references" do
+        expect do
+          Class.new(TestClassBase) do
+            self.table_name = 'test_classes'
+            virtual_delegate :col4, :to => :others, :type => :integer
+          end.new
+        end.to raise_error
       end
     end
 


### PR DESCRIPTION
Alternate to #20 

Allow virtual delegate to be specified or discovered

For the most part, discovery works great.
Unfortunately it can cause a cascade of `load_schema` calls for the referenced classes.
This causes issues when we are doing a bunch of blanket field discovery calls.

This is related to:

- https://github.com/ManageIQ/manageiq-api/pull/416/files
- https://bugzilla.redhat.com/show_bug.cgi?id=1700378