### PR TITLE
Support rails 5.1 for preloading values. Also reduce monkey patching

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -40,6 +40,7 @@ module ActiveRecord
             associations.each_with_object({}) do |(parent, child), h|
               next if virtual_field?(parent)
               reflection = reflect_on_association(parent.to_sym)
+              raise ArgumentError, "Unknown association #{parent}" unless reflection
               h[parent] = reflection.options[:polymorphic] ? nil : reflection.klass.remove_virtual_fields(child) if reflection
             end
           else

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -41,7 +41,7 @@ module ActiveRecord
               next if virtual_field?(parent)
               reflection = reflect_on_association(parent.to_sym)
               raise ArgumentError, "Unknown association #{parent}" unless reflection
-              h[parent] = reflection.options[:polymorphic] ? nil : reflection.klass.remove_virtual_fields(child) if reflection
+              h[parent] = reflection.options[:polymorphic] ? {} : reflection.klass.remove_virtual_fields(child) || {} if reflection
             end
           else
             associations

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -62,8 +62,14 @@ class Author < VitualTotalTestBase
     books.first.author_name
   end
 
+  def upper_first_book_author_name
+    first_book_author_name.upcase
+  end
+
   virtual_attribute :first_book_name, :string, :uses => [:books]
   virtual_attribute :first_book_author_name, :string, :uses => {:books => :author_name}
+  # uses another virtual attribute that uses a relation
+  virtual_attribute :upper_first_book_author_name, :string, :uses => :first_book_author_name
 
   def self.create_with_books(count)
     create!(:name => "foo").tap { |author| author.create_books(count) }
@@ -86,6 +92,18 @@ class Book < VitualTotalTestBase
   # this tests delegate
   # this also tests an attribute :uses clause with a single symbol
   virtual_delegate :name, :to => :author, :prefix => true
+
+  # simple uses to a virtual attribute
+  virtual_attribute :upper_author_name, :string, :uses => [:author_name]
+  virtual_attribute :upper_author_name_def, :string, :uses => :upper_author_name
+
+  def upper_author_name
+    author_name.upcase
+  end
+
+  def upper_author_name_def
+    upper_author_name || "other"
+  end
 
   def self.create_with_bookmarks(count)
     Author.create(:name => "foo").books.create!(:name => "book").tap { |book| book.create_bookmarks(count) }

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -164,7 +164,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           expect(test_sub_class.remove_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
           expect(test_sub_class.remove_virtual_fields({:vcol1    => {}})).to eq({})
           expect(test_sub_class.remove_virtual_fields({:vcolsub1 => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields(:vcolsub1 => {}, :volsub1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+          expect(test_sub_class.remove_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq({:ref1 => {}})
         end
       end
     end

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -122,13 +122,13 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(TestClass.remove_virtual_fields(:vcol1)).to          be_nil
-          expect(TestClass.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(TestClass.remove_virtual_fields([:vcol1])).to eq([])
-          expect(TestClass.remove_virtual_fields([:vcol1, :ref1])).to eq([:ref1])
-          expect(TestClass.remove_virtual_fields(:vcol1 => {})).to eq({})
-          expect(TestClass.remove_virtual_fields(:vcol1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(TestClass.replace_virtual_fields(:vcol1)).to be_nil
+          expect(TestClass.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(TestClass.replace_virtual_fields([:vcol1])).to eq([])
+          expect(TestClass.replace_virtual_fields([:vcol1, :ref1])).to eq([:ref1])
+          expect(TestClass.replace_virtual_fields(:vcol1 => {})).to eq({})
+          expect(TestClass.replace_virtual_fields(:vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end
@@ -155,16 +155,16 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(test_sub_class.remove_virtual_fields(:vcol1)).to             be_nil
-          expect(test_sub_class.remove_virtual_fields(:vcolsub1)).to          be_nil
-          expect(test_sub_class.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(test_sub_class.remove_virtual_fields([:vcol1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vcolsub1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
-          expect(test_sub_class.remove_virtual_fields({:vcol1    => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields({:vcolsub1 => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(test_sub_class.replace_virtual_fields(:vcol1)).to             be_nil
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1)).to          be_nil
+          expect(test_sub_class.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(test_sub_class.replace_virtual_fields([:vcol1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vcolsub1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
+          expect(test_sub_class.replace_virtual_fields(:vcol1    => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1 => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end
@@ -336,13 +336,13 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(TestClass.remove_virtual_fields(:vref1)).to          be_nil
-          expect(TestClass.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(TestClass.remove_virtual_fields([:vref1])).to eq([])
-          expect(TestClass.remove_virtual_fields([:vref1, :ref1])).to eq([:ref1])
-          expect(TestClass.remove_virtual_fields(:vref1 => {})).to eq({})
-          expect(TestClass.remove_virtual_fields(:vref1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(TestClass.replace_virtual_fields(:vref1)).to be_nil
+          expect(TestClass.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(TestClass.replace_virtual_fields([:vref1])).to eq([])
+          expect(TestClass.replace_virtual_fields([:vref1, :ref1])).to eq([:ref1])
+          expect(TestClass.replace_virtual_fields(:vref1 => {})).to eq({})
+          expect(TestClass.replace_virtual_fields(:vref1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end
@@ -371,16 +371,16 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           end
         end
 
-        it ".remove_virtual_fields" do
-          expect(test_sub_class.remove_virtual_fields(:vref1)).to             be_nil
-          expect(test_sub_class.remove_virtual_fields(:vrefsub1)).to          be_nil
-          expect(test_sub_class.remove_virtual_fields(:ref1)).to eq(:ref1)
-          expect(test_sub_class.remove_virtual_fields([:vref1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vrefsub1])).to eq([])
-          expect(test_sub_class.remove_virtual_fields([:vrefsub1, :vref1, :ref1])).to eq([:ref1])
-          expect(test_sub_class.remove_virtual_fields({:vref1    => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields({:vrefsub1 => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields(:vrefsub1 => {}, :vref1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+        it ".replace_virtual_fields" do
+          expect(test_sub_class.replace_virtual_fields(:vref1)).to be_nil
+          expect(test_sub_class.replace_virtual_fields(:vrefsub1)).to be_nil
+          expect(test_sub_class.replace_virtual_fields(:ref1)).to eq(:ref1)
+          expect(test_sub_class.replace_virtual_fields([:vref1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vrefsub1])).to eq([])
+          expect(test_sub_class.replace_virtual_fields([:vrefsub1, :vref1, :ref1])).to eq([:ref1])
+          expect(test_sub_class.replace_virtual_fields(:vref1 => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vrefsub1 => {})).to eq({})
+          expect(test_sub_class.replace_virtual_fields(:vrefsub1 => {}, :vref1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -83,14 +83,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "preloads virtual_attribute (:uses => :book)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:first_book_name).references(:first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes([:first_book_name]).references(:first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes(:first_book_name => {}).references(:first_book_name => {})).to preload_values(:first_book_name, book_name)
     end
 
     it "preloads virtual_attribute (delegate defines :uses => :author)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Book.includes(:author_name).references(:author_name => {})).to preload_values(:author_name, author_name)
       expect(Book.includes([:author_name]).references(:author_name => {})).to preload_values(:author_name, author_name)
       expect(Book.includes(:author_name => {}).references(:author_name => {})).to preload_values(:author_name, author_name)
@@ -103,14 +101,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "preloads virtual_attribute (multiple)" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:nick_or_name).includes(:first_book_name).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes([:nick_or_name, :first_book_name]).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
       expect(Author.includes(:nick_or_name => {}, :first_book_name => {}).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
     end
 
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:first_book_author_name).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes([:first_book_author_name]).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:first_book_author_name => {}).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
@@ -124,7 +120,6 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "uses included associations" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => [:author]).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author => {}}).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
@@ -135,31 +130,34 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "uses included fields" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "uses preloaded fields" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       inc = Author.virtual_includes(:first_book_author_name)
       expect(Author.includes(inc).references(inc)).to preload_values(:first_book_author_name, author_name)
     end
+
+    it "detects errors" do
+      expect { Author.includes(:invalid).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+      expect { Author.includes(:books => :invalid).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+      expect { Author.includes(:books => [:invalid]).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+      expect { Author.includes(:books => {:invalid => {}}).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+    end
   end
 
   context "preloads virtual_attribute with select.includes.references" do
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Book.select(:author_name).includes(:author_name).references(:author_name)).to preload_values(:author_name, author_name)
     end
   end
 
   it "preloads virtual_attribute in :include when :conditions are also present in calculations" do
-    skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.name = '#{author_name}'")).to preload_values(:author_name, author_name)
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.id IS NOT NULL")).to preload_values(:author_name, author_name)
   end
@@ -189,14 +187,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
   context "preloads virtual_reflection with includes.references" do
     it "preloads virtual_reflection (:uses => [:books])" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:named_books).references(:named_books => {})).to preload_values(:named_books, named_books)
       expect(Author.includes([:named_books]).references(:named_books => {})).to preload_values(:named_books, named_books)
       expect(Author.includes(:named_books => {}).references(:named_books => {})).to preload_values(:named_books, named_books)
     end
 
     it "preloads virtual_reflection (:uses => {:books => :author_name})" do
-      skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books_with_authors).references(:books_with_authors => {})).to preload_values(:books_with_authors, named_books)
       expect(Author.includes([:books_with_authors]).references(:books_with_authors => {})).to preload_values(:books_with_authors, named_books)
       expect(Author.includes(:books_with_authors => {}).references(:books_with_authors => {})).to preload_values(:books_with_authors, named_books)

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -41,6 +41,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Book.includes(:author_name => {})).to preload_values(:author_name, author_name)
     end
 
+    it "preloads virtual_attribute (:uses => :upper_author_name) (:uses => :author_name)" do
+      expect(Book.includes(:upper_author_name_def)).to preload_values(:upper_author_name_def, author_name.upcase)
+      expect(Book.includes([:upper_author_name_def])).to preload_values(:upper_author_name_def, author_name.upcase)
+      expect(Book.includes(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
+    end
+
     it "preloads virtual_attribute (multiple)" do
       expect(Author.includes(:nick_or_name).includes(:first_book_name)).to preload_values(:first_book_name, book_name)
       expect(Author.includes([:nick_or_name, :first_book_name])).to preload_values(:first_book_name, book_name)
@@ -51,6 +57,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:first_book_author_name)).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes([:first_book_author_name])).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
+    end
+
+    it "preloads virtual_attributes (:uses => {:first_book_author_name}) which (:uses => {:books => :author_name})" do
+      expect(Author.includes(:upper_first_book_author_name)).to preload_values(:upper_first_book_author_name, author_name.upcase)
+      expect(Author.includes([:upper_first_book_author_name])).to preload_values(:upper_first_book_author_name, author_name.upcase)
+      expect(Author.includes(:upper_first_book_author_name => {})).to preload_values(:upper_first_book_author_name, author_name.upcase)
     end
 
     it "uses included associations" do
@@ -84,6 +96,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Book.includes(:author_name => {}).references(:author_name => {})).to preload_values(:author_name, author_name)
     end
 
+    it "preloads virtual_attribute (:uses => :upper_author_name) (:uses => :author_name)" do
+      expect(Book.includes(:upper_author_name_def).references(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
+      expect(Book.includes([:upper_author_name_def]).references(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
+      expect(Book.includes(:upper_author_name_def => {}).references(:upper_author_name_def => {})).to preload_values(:upper_author_name_def, author_name.upcase)
+    end
+
     it "preloads virtual_attribute (multiple)" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:nick_or_name).includes(:first_book_name).references(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
@@ -96,6 +114,13 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:first_book_author_name).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes([:first_book_author_name]).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:first_book_author_name => {}).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
+    end
+
+    it "preloads virtual_attributes (:uses => {:first_book_author_name}) which (:uses => {:books => :author_name})" do
+      ref = {:first_book_author_name => {}}
+      expect(Author.includes(:upper_first_book_author_name).references(ref)).to preload_values(:upper_first_book_author_name, author_name.upcase)
+      expect(Author.includes([:upper_first_book_author_name]).references(ref)).to preload_values(:upper_first_book_author_name, author_name.upcase)
+      expect(Author.includes(:upper_first_book_author_name => {}).references(ref)).to preload_values(:upper_first_book_author_name, author_name.upcase)
     end
 
     it "uses included associations" do

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -126,28 +126,28 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "uses included associations" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author]).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author]).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author => {}}).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
 
-      # expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name =>{}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "uses included fields" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
-      # expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "uses preloaded fields" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
-      # expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # inc = Author.virtual_includes(:first_book_author_name)
-      # expect(Author.includes(inc).references(inc)).to preload_values(:first_book_author_name, author_name)
+      inc = Author.virtual_includes(:first_book_author_name)
+      expect(Author.includes(inc).references(inc)).to preload_values(:first_book_author_name, author_name)
     end
   end
 


### PR DESCRIPTION
### Description

Alternate to #16  (it builds upon it really)

Instead of monkey patching internal methods, this patches the methods where the developer passes in the virtual Attributes.

### Overview

We call `includes().references().select().order()` with virtual_attributes, or virtual_includes.

Some code needs to change the virtual attributes we pass in, over to the real models that rails can actually use.

### Before

We store the passed in values in `includes()` and `references()`. At query time we convert those values to the appropriate values.

Unfortunately, these internal classes change a bunch over the rails versions (and sometimes within a rails bug version).

### After

We change the passed in values in `includes()` and `references()` to be the actual values we want to use at query time. At query time there is no need to do anything special.

These methods are relatively public in nature and do not change that often. This makes maintaining multiple versions much easier.
