### PR TITLE
Fix poly references

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -40,7 +40,7 @@ module ActiveRecord
             associations.each_with_object({}) do |(parent, child), h|
               next if virtual_field?(parent)
               reflection = reflect_on_association(parent.to_sym)
-              h[parent] = reflection.nil? || reflection.options[:polymorphic] ? nil : reflection.klass.remove_virtual_fields(child)
+              h[parent] = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.remove_virtual_fields(child) || {}
             end
           else
             associations

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -40,7 +40,7 @@ module ActiveRecord
             associations.each_with_object({}) do |(parent, child), h|
               next if virtual_field?(parent)
               reflection = reflect_on_association(parent.to_sym)
-              h[parent] = reflection.options[:polymorphic] ? nil : reflection.klass.remove_virtual_fields(child) if reflection
+              h[parent] = reflection.nil? || reflection.options[:polymorphic] ? nil : reflection.klass.remove_virtual_fields(child)
             end
           else
             associations

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -79,6 +79,8 @@ end
 class Book < VitualTotalTestBase
   has_many :bookmarks, :class_name => "Bookmark", :foreign_key => "book_id"
   belongs_to :author,  :class_name => "Author",   :foreign_key => "author_id"
+  belongs_to :author_or_bookmark, :polymorphic => true, :foreign_key => "author_id", :foreign_type => "author_type"
+
   scope :ordered,   -> { order(:created_on => :desc) }
   scope :published, -> { where(:published => true)  }
   scope :wip,       -> { where(:published => false) }

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define(:version => 0) do
 
   create_table "books", :force => true do |t|
     t.integer  "author_id"
+    t.string   "author_type", :default => "Author"
     t.string   "name"
     t.boolean  "published", :default => false
     t.boolean  "special",   :default => false

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -164,7 +164,7 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
           expect(test_sub_class.remove_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
           expect(test_sub_class.remove_virtual_fields({:vcol1    => {}})).to eq({})
           expect(test_sub_class.remove_virtual_fields({:vcolsub1 => {}})).to eq({})
-          expect(test_sub_class.remove_virtual_fields(:vcolsub1 => {}, :volsub1 => {}, :ref1 => {})).to eq({:ref1 => {}})
+          expect(test_sub_class.remove_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
         end
       end
     end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -53,6 +53,11 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
     end
 
+    it "preloads through polymorphic" do
+      books = Book.includes(:author_or_bookmark => :total_books).load
+      expect { expect(books.map { |b| b.author_or_bookmark.total_books }).to eq([3, 3, 3]) }.to match_query_limit_of(0)
+    end
+
     it "uses included associations" do
       expect(Author.includes(:books => :author)).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
@@ -96,6 +101,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:first_book_author_name).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes([:first_book_author_name]).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:first_book_author_name => {}).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
+    end
+
+    it "doesn't preloads through polymorphic" do
+      expect do
+        Book.includes(:author_or_bookmark => :total_books).references(:author_name).load
+      end.to raise_error(ActiveRecord::EagerLoadPolymorphicError)
     end
 
     it "uses included associations" do

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -101,28 +101,28 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "uses included associations" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
       expect(Author.includes(:books => :author).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author]).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author]).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author => {}}).references(:books => {:author => {}})).to preload_values(:first_book_author_name, author_name)
 
-      # expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name =>{}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "uses included fields" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
-      # expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "uses preloaded fields" do
       skip("AR 5.1 not including properly") if ActiveRecord.version.to_s >= "5.1"
-      # expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => :author_name).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
+      expect(Author.includes(:books => [:author_name]).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(:books => {:author_name => {}}).references(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
-      # inc = Author.virtual_includes(:first_book_author_name)
-      # expect(Author.includes(inc).references(inc)).to preload_values(:first_book_author_name, author_name)
+      inc = Author.virtual_includes(:first_book_author_name)
+      expect(Author.includes(inc).references(inc)).to preload_values(:first_book_author_name, author_name)
     end
 
     it "detects errors" do

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -124,6 +124,14 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       # inc = Author.virtual_includes(:first_book_author_name)
       # expect(Author.includes(inc).references(inc)).to preload_values(:first_book_author_name, author_name)
     end
+
+    it "detects errors" do
+      expect { Author.includes(:books).references(:books).load }.not_to raise_error
+      expect { Author.includes(:invalid).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+      expect { Author.includes(:books => :invalid).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+      expect { Author.includes(:books => [:invalid]).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+      expect { Author.includes(:books => {:invalid => {}}).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
+    end
   end
 
   context "preloads virtual_attribute with select.includes.references" do


### PR DESCRIPTION
Fixes an issue when an includes references a column without using hashes.

invalid columns were silently failing in many cases.
Which is a problem because it was missing some includes.
This plugs that hole so we can properly fix these problems when we see them

```ruby
# before:
Author.includes(:books => [:author]).references(:books => {:author => {}}).map(&:name)

     ActiveRecord::ConfigurationError:
       nil
     # /Users/kbrock/.gem/ruby/2.5.5/gems/activerecord-5.0.7.2/lib/active_record/associations/join_dependency.rb:70:in `walk_tree'
     # /Users/kbrock/.gem/ruby/2.5.5/gems/activerecord-5.0.7.2/lib/active_record/associations/join_dependency.rb:67:in `block in walk_tree'
     # /Users/kbrock/.gem/ruby/2.5.5/gems/activerecord-5.0.7.2/lib/active_record/associations/join_dependency.rb:65:in `each'
     # /Users/kbrock/.gem/ruby/2.5.5/gems/activerecord-5.0.7.2/lib/active_record/associations/join_dependency.rb:65:in `walk_tree'
...

# after:

Author.includes(:books => [:author]).references(:books => {:author => {}}).to_a
["foo", "foo", "foo"]
```

Also

```ruby
# before:
 Author.includes(:books => {:invalid => {}}).references(:books).map(&:name)
["foo", "foo", "foo"]

# after:
 Author.includes(:books => {:invalid => {}}).references(:books).map(&:name)
     ActiveRecord::ConfigurationError:
       Can't join 'Author' to association named 'invalid'; perhaps you misspelled it?
     # /Users/kbrock/.gem/ruby/2.5.5/gems/activerecord-5.0.7.2/lib/active_record/associations/join_dependency.rb:231:in `find_reflection'
     # /Users/kbrock/.gem/ruby/2.5.5/gems/activerecord-5.0.7.2/lib/active_record/associations/join_dependency.rb:236:in `block in build'
```