### PR TITLE
Column aliases

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -207,8 +207,12 @@ module ActiveRecord
         # this code is based upon _select()
         fields.flatten!
         fields.map! do |field|
-          if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as)
-            arel.as(connection.quote_column_name(field.to_s))
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field))
+            if arel.respond_to?(:as) && !arel.try(:alias)
+              arel.as(connection.quote_column_name(field.to_s))
+            else
+              arel
+            end
           else
             field
           end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -208,7 +208,7 @@ module ActiveRecord
         fields.flatten!
         fields.map! do |field|
           if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as)
-            arel.as(field.to_s)
+            arel.as(connection.quote_column_name(field.to_s))
           else
             field
           end

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -983,6 +983,54 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
     expect(tc.send("lower column")).to eq("abc")
   end
 
+  context "arel", "aliases" do
+    it "supports aliased virtual attribute arel with functions", :with_test_class do
+      class TestClass
+        # using an alias is not suggested. it will fail if used in an `order` or `where` clauses
+        virtual_attribute :lc, :string, :arel => ->(t) { t[:str].lower.as("downcased") }
+        def lc
+          has_attribute?(:downcased) ? self[:downcased] : str.downcase
+        end
+      end
+
+      obj = TestClass.create(:str => "ABC")
+
+      tc = TestClass.select(:lc).find_by(:id => obj.id)
+      expect(tc.lc).to eq("abc")
+    end
+
+    # grouping is the most common way to define arel
+    it "supports aliased virtual attribute arel with grouping", :with_test_class do
+      class TestClass
+        # using an alias is not suggested. it will fail if used in an `order` or `where` clauses
+        virtual_attribute :lc, :string, :arel => ->(t) { Arel.sql("(#{t[:str].lower.to_sql})") }
+        def lc
+          has_attribute?(:lc) ? self[:lc] : str.downcase
+        end
+      end
+
+      obj = TestClass.create(:str => "ABC")
+
+      tc = TestClass.select(:lc).find_by(:id => obj.id)
+      expect(tc.lc).to eq("abc")
+    end
+
+    it "supports aliased virtual attribute arel with nodes", :with_test_class do
+      class TestClass
+        # using an alias is not suggested. it will fail if used in an `order` or `where` clauses
+        virtual_attribute :lc, :string, :arel => ->(t) { Arel::Nodes::As.new(t[:str].lower, Arel.sql("downcased")) }
+        def lc
+          has_attribute?(:downcased) ? self[:downcased] : str.downcase
+        end
+      end
+
+      obj = TestClass.create(:str => "ABC")
+
+      tc = TestClass.select(:lc).find_by(:id => obj.id)
+      expect(tc.lc).to eq("abc")
+    end
+  end
+
   it "doesn't botch up the attributes", :with_test_class do
     tc = TestClass.select(:id, :str).find(TestClass.create(:str => "abc", :col1 => 55).id)
     expect(tc.attributes.size).to eq(2)

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -971,6 +971,18 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
     end
   end
 
+  it "supports non valid sql column names", :with_test_class do
+    TestClass.create(:str => "ABC")
+    TestClass.virtual_attribute :"lower column", :string, :arel => ->(t) { t[:str].lower }
+    class TestClass
+      define_method("lower column") { has_attribute?(:"lower column") ? self[:"lower column"] : str.downcase }
+    end
+
+    # testing both the select and the where
+    tc = TestClass.select("lower column").order(:"lower column").find_by(:"lower column" => "abc")
+    expect(tc.send("lower column")).to eq("abc")
+  end
+
   it "doesn't botch up the attributes", :with_test_class do
     tc = TestClass.select(:id, :str).find(TestClass.create(:str => "abc", :col1 => 55).id)
     expect(tc.attributes.size).to eq(2)


### PR DESCRIPTION
ManageIQ/manageiq: Custom Attributes define :arel with an alias.

This allows the custom attributes to be defined without an alias
And this fixes an edge case when an alias is defined

To be honest, we should probably remove the custom alias for the custom attributes when defining the virtual attributes - but this PR is needed for that case as well.

Also, this refactored that method to make rubocop happy