### PR TITLE
quote column aliases

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -208,7 +208,7 @@ module ActiveRecord
         fields.flatten!
         fields.map! do |field|
           if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as)
-            arel.as(field.to_s)
+            arel.as(connection.quote_column_name(field.to_s))
           else
             field
           end

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -971,6 +971,18 @@ describe ActiveRecord::VirtualAttributes::VirtualFields do
     end
   end
 
+  it "supports non valid sql column names", :with_test_class do
+    TestClass.create(:str => "ABC")
+    TestClass.virtual_attribute :"lower column", :string, :arel => ->(t) { t[:str].lower }
+    class TestClass
+      define_method("lower column") { has_attribute?(:"lower column") ? self[:"lower column"] : str.downcase }
+    end
+
+    # testing the select, order, and where clauses
+    tc = TestClass.select("lower column").order(:"lower column").find_by(:"lower column" => "abc")
+    expect(tc.send("lower column")).to eq("abc")
+  end
+
   it "doesn't botch up the attributes", :with_test_class do
     tc = TestClass.select(:id, :str).find(TestClass.create(:str => "abc", :col1 => 55).id)
     expect(tc.attributes.size).to eq(2)


### PR DESCRIPTION
properly quote virtual attribute names

Sometimes the attribute name is not sql friendly.
the will properly quote the attribute name

In our case, custom attributes sometimes have non sql friendly name for the virtual attribute. this escapes the code and makes us all happy

NOTE: this is the first commit from #27 -- I wanted that code to stick around so I created this smaller PR