### PR TITLE
refactor: simplify virtual_aggregate and virtual_total

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -53,6 +53,8 @@ module VirtualAttributes
       #    # arel => (SELECT sum("disks"."size") where "hardware"."id" = "disks"."hardware_id")
 
       def virtual_aggregate(name, relation, method_name = :sum, column = nil, options = {})
+        return define_virtual_total(name, relation, options) if method_name == :size
+
         define_virtual_aggregate_method(name, relation, method_name, column)
         define_virtual_aggregate_attribute(name, relation, method_name, column, options)
       end

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -25,7 +25,8 @@ module VirtualAttributes
       #   # arel == (SELECT COUNT(*) FROM vms where ems.id = vms.ems_id)
       #
       def virtual_total(name, relation, options = {})
-        virtual_aggregate(name, relation, :size, nil, options)
+        define_virtual_aggregate_method(name, relation, :size, nil)
+        define_virtual_aggregate_attribute(name, relation, :size, nil, options)
       end
 
       # define an attribute to calculate the sum of a has may relationship
@@ -53,6 +54,10 @@ module VirtualAttributes
 
       def virtual_aggregate(name, relation, method_name = :sum, column = nil, options = {})
         define_virtual_aggregate_method(name, relation, method_name, column)
+        define_virtual_aggregate_attribute(name, relation, method_name, column, options)
+      end
+
+      def define_virtual_aggregate_attribute(name, relation, method_name, column, options)
         reflection = reflect_on_association(relation)
 
         if options.key?(:arel)

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -5,14 +5,9 @@ module VirtualAttributes
     module ClassMethods
       private
 
-      # define an attribute to calculating the total of a child
-      def virtual_total(name, relation, options = {})
-        virtual_aggregate(name, relation, :size, nil, options)
-      end
-
-      # define an attribute to calculating the total of a child
+      # define an attribute to calculating the total of a has many relationship
       #
-      #  example 1:
+      #  example:
       #
       #    class ExtManagementSystem
       #      has_many :vms
@@ -29,7 +24,13 @@ module VirtualAttributes
       #
       #   # arel == (SELECT COUNT(*) FROM vms where ems.id = vms.ems_id)
       #
-      #  example 2:
+      def virtual_total(name, relation, options = {})
+        virtual_aggregate(name, relation, :size, nil, options)
+      end
+
+      # define an attribute to calculate the sum of a has may relationship
+      #
+      #  example:
       #
       #    class Hardware
       #      has_many :disks


### PR DESCRIPTION
This fixes Code Climate issues:

```
Method define_virtual_aggregate_method has a Cognitive Complexity of 20
(exceeds 11 allowed). Consider refactoring. 
```

### what was done

- This makes no functional changes.
- It splits a method into 3 methods - to appease CodeClimate and me.
- added virtual_aggregate :size method to handle cases where someone used `virtual_aggregates` instead of `virtual_totals` (not sure if we should support this, but put in just in case)

### reviewing tips

viewing with `ignoring whitespace` makes it a little more obvious that stuff is just moved around