### PR TITLE
Add support for left outer joins (fix turbo button)

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -221,6 +221,12 @@ module ActiveRecord
         super
       end
 
+      # From ActiveRecord::QueryMethods
+      def build_left_outer_joins(manager, outer_joins, *rest)
+        outer_joins = klass.replace_virtual_fields(outer_joins)
+        super if outer_joins.present?
+      end
+
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
         # work around 1 until https://github.com/rails/rails/pull/25304 gets merged

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -227,4 +227,12 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:book_with_most_bookmarks).references(:book_with_most_bookmarks)).to preload_values(:book_with_most_bookmarks, bookmarked_book)
     end
   end
+
+  context "supports left_joins with virtual attributes" do
+    it "doesn't freak when virtual attribute in " do
+      # sorry, :author_name will not be available
+      # in that case, just .where.not(:author_name => nil) - no need for left_joins
+      expect { Book.left_joins(:author_name).where.not(:authors => {:name => nil}).load }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
if we use virtual attributes in outer joins, then translate the column

### Overview

In MIQ, the turbo button uses `left_joins` instead of `references`

https://github.com/ManageIQ/manageiq/pull/18892

### Before

- `references`/`includes` properly translate virtual attributes  :+1:
- `left_joins` will not  :-1:

So when using the turbo button, reports blew up.

```
ActiveRecord::ConfigurationError:
    Can't join 'ExtManagementSystem' to association named 'hostname'; perhaps you misspelled it?
 ```

### After

- `references`/`includes` properly translate virtual attributes :+1:
- `left_joins` properly translate virtual attributes :+1:

turbo button works.

