### PR TITLE
Support bye bug

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activerecord", ">= 5.0"
 
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"

--- a/spec/support/byebug.rb
+++ b/spec/support/byebug.rb
@@ -1,0 +1,4 @@
+begin
+  require "byebug"
+rescue LoadError
+end


### PR DESCRIPTION
not happy having byebug as a development dependency

but it just became too hard to constantly add this and comment it out

Of Note: Despite what rubocop says, MiQ core includes the byebug gem