### PR TITLE
refactor use of deep_merge

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -51,7 +51,11 @@ module ActiveRecord
               merge_includes(h, replace_virtual_fields(virtual_includes(parent)))
             else
               reflection = reflect_on_association(parent.to_sym)
-              new_child = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.replace_virtual_fields(child) || {}
+              if reflection.nil? || reflection.options[:polymorphic]
+                new_child = {}
+              else
+                new_child = reflection.klass.replace_virtual_fields(child) || {}
+              end
               merge_includes(h, parent => new_child)
             end
           end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -52,11 +52,10 @@ module ActiveRecord
             else
               reflection = reflect_on_association(parent.to_sym)
               if reflection.nil? || reflection.options[:polymorphic]
-                new_child = {}
+                merge_includes(h, parent)
               else
-                new_child = reflection.klass.replace_virtual_fields(child) || {}
+                merge_includes(h, parent => reflection.klass.replace_virtual_fields(child) || {})
               end
-              merge_includes(h, parent => new_child)
             end
           end
         end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -48,8 +48,7 @@ module ActiveRecord
         def replace_virtual_field_hash(associations)
           associations.each_with_object({}) do |(parent, child), h|
             if virtual_field?(parent) # form virtual_attribute => {}
-              new_includes = replace_virtual_fields(virtual_includes(parent))
-              merge_includes(h, new_includes)
+              merge_includes(h, replace_virtual_fields(virtual_includes(parent)))
             else
               reflection = reflect_on_association(parent.to_sym)
               new_child = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.replace_virtual_fields(child) || {}

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -48,14 +48,8 @@ module ActiveRecord
         def replace_virtual_field_hash(associations)
           associations.each_with_object({}) do |(parent, child), h|
             if virtual_field?(parent) # form virtual_attribute => {}
-              case (new_includes = replace_virtual_fields(virtual_includes(parent)))
-              when String, Symbol
-                merge_includes(h, new_includes)
-              when Array
-                merge_includes(h, new_includes)
-              when Hash
-                merge_includes(h, new_includes)
-              end
+              new_includes = replace_virtual_fields(virtual_includes(parent))
+              merge_includes(h, new_includes)
             else
               reflection = reflect_on_association(parent.to_sym)
               new_child = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.replace_virtual_fields(child) || {}


### PR DESCRIPTION
Depends:

- [x] #36 first 2 commits

Now that the merge works more inclusively, many of these `case` statements are no longer necessary