### PR TITLE
fix broken bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,12 +3,9 @@
 require "bundler/setup"
 require "active_record-virtual_attributes"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+# models for local testing
+require "rspec"
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 require "irb"
 IRB.start(__FILE__)

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "virtual_attributes"
+require "active_record-virtual_attributes"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,1 @@
-require 'virtual_attributes'
+require 'active_record-virtual_attributes'


### PR DESCRIPTION
the gem was renamed, but the new name was not added to `./bin/console`

This also now connects to an empty test database (as suggested by the bin/console file) so it can be tested and exercised in the console.


### before

```
./bin/console
Traceback (most recent call last):
	1: from ./bin/console:4:in `<main>'
./bin/console:4:in `require': cannot load such file -- virtual_attributes (LoadError)
```

### after

```
./bin/console
>Author.create_with_books(5)
# => #<Author id: 1, name: "foo", nickname: nil>  
>Author.count
# => 1  
>Book.count
# => 5  
```
