### PR TITLE
virtual includes - better deep merge for attributes

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -50,9 +50,9 @@ module ActiveRecord
             if virtual_field?(parent) # form virtual_attribute => {}
               case (new_includes = replace_virtual_fields(virtual_includes(parent)))
               when String, Symbol
-                merge_includes(h, new_includes => {})
+                merge_includes(h, new_includes)
               when Array
-                merge_includes(h, new_includes.each_with_object({}) { |association, h2| h2[association] = {} })
+                merge_includes(h, new_includes)
               when Hash
                 merge_includes(h, new_includes)
               end
@@ -64,11 +64,28 @@ module ActiveRecord
           end
         end
 
+        # @param [Hash, Array, String, Symbol] value
+        # @return [Hash]
+        def include_to_hash(value)
+          case value
+          when String, Symbol
+            {value => {}}
+          when Array
+            value.flatten.each_with_object({}) { |k, h| h[k] = {} }
+          when nil
+            {}
+          else
+            value
+          end
+        end
+
         # @param [Hash] hash1
         # @param [Hash] hash2
         def merge_includes(hash1, hash2)
           return hash1 if hash2.blank?
 
+          hash1 = include_to_hash(hash1)
+          hash2 = include_to_hash(hash2)
           hash1.deep_merge!(hash2) do |_k, v1, v2|
             merge_includes(v1, v2)
           end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -50,16 +50,27 @@ module ActiveRecord
             if virtual_field?(parent) # form virtual_attribute => {}
               case (new_includes = replace_virtual_fields(virtual_includes(parent)))
               when String, Symbol
-                h[new_includes] = {}
+                merge_includes(h, new_includes => {})
               when Array
-                new_includes.each { |association| h[association] = {} }
+                merge_includes(h, new_includes.each_with_object({}) { |association, h2| h2[association] = {} })
               when Hash
-                h.deep_merge!(new_includes)
+                merge_includes(h, new_includes)
               end
             else
               reflection = reflect_on_association(parent.to_sym)
-              h[parent] = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.replace_virtual_fields(child) || {}
+              new_child = reflection.nil? || reflection.options[:polymorphic] ? {} : reflection.klass.replace_virtual_fields(child) || {}
+              merge_includes(h, parent => new_child)
             end
+          end
+        end
+
+        # @param [Hash] hash1
+        # @param [Hash] hash2
+        def merge_includes(hash1, hash2)
+          return hash1 if hash2.blank?
+
+          hash1.deep_merge!(hash2) do |_k, v1, v2|
+            merge_includes(v1, v2)
           end
         end
       end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -53,6 +53,10 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:nick_or_name => {}, :first_book_name => {})).to preload_values(:first_book_name, book_name)
     end
 
+    it "preloads virtual_attributes dups" do
+      expect(Author.includes(:total_named_books).includes(:first_book_author_name)).to preload_values(:first_book_author_name, author_name)
+    end
+
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
       expect(Author.includes(:first_book_author_name)).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes([:first_book_author_name])).to preload_values(:first_book_author_name, author_name)
@@ -122,6 +126,10 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:books_with_authors => {}, :books => {}).references(:books => {})).to preload_values(:books_with_authors, named_books)
       expect(Author.includes(:books => {}).includes(:books => {:author => {}}).references(:books => {})).to preload_values(:books_with_authors, named_books)
       expect(Author.includes(:books => {:author => {}}).includes(:books => {}).references(:books => {})).to preload_values(:books_with_authors, named_books)
+    end
+
+    it "preloads virtual_attributes dups" do
+      expect(Author.includes(:books => :author, :books_with_authors => {}).references(:first_book_author_name => {})).to preload_values(:first_book_author_name, author_name)
     end
 
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
@@ -286,6 +294,20 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "merges hash, hash - 1 level only" do
       first  = {:key => {:more1 => {}}}
       second = {:key => {:more2 => {}}}
+      result = {:key => {:more1 => {}, :more2 => {}}}
+      expect(Author.merge_includes(first, second)).to eq(result)
+    end
+
+    it "merges hash(hash), hash(symbol)" do
+      first  = {:key => {:more1 => {}}}
+      second = {:key => :more2}
+      result = {:key => {:more1 => {}, :more2 => {}}}
+      expect(Author.merge_includes(first, second)).to eq(result)
+    end
+
+    it "merges hash(hash), hash(array)" do
+      first  = {:key => {:more1 => {}}}
+      second = {:key => [:more2]}
       result = {:key => {:more1 => {}, :more2 => {}}}
       expect(Author.merge_includes(first, second)).to eq(result)
     end


### PR DESCRIPTION
### Bug

We have a performance regression on the VMs page (`VmOrTemplate.yaml`)
Sometimes the page loads objects great, and other times it does an N+1 on `disks`.

This is a subset of #34 

### Overview

The issue stems around with the way we handle `includes()` to load the objects for the VMs page.

```ruby
class VmOrTemplate
  belongs_to :hardware
  virtual_delegate :allocated_disk_storage, :uses => {:hardware => :disks}
end
```

For our views, we generate `includes()` for all virtual columns and associated tables:
- `hardware.name` -- `includes(:hardware)`
- `allocated_disk_storage` -- `includes(:hardware => :disks)` /via `:uses`

```ruby
VmOrTemplate.includes(:hardware).includes(:hardware => :disks).each do |vm|
  puts "#{vm.id} #{vm.hardware.name} #{vm.allocated_disk_storage)
end
```

The issue is when you merge the 2 different nested hashes from the `includes()`.
The algorithm is broken and would generate 1 of 2 possible `includes`:

```ruby
# look up all vms, all hardware, disks for each hardware record (N+2 queries)
VmOrTemplate.includes(:hardware).each do |vm|
  puts "#{vm.id} #{vm.hardware.name} #{vm.allocated_disk_storage)
end

# look up all vms, all hardware, all disks (3 queries)
VmOrTemplate.includes(:hardware => :disks).each do |vm|
  puts "#{vm.id} #{vm.hardware.name} #{vm.allocated_disk_storage)
end
```

### After

`replace_virtual_field_hash` is revamped to produce consistent results.
And bonus, it returns is the hash with all the associations:

`VmOrTemplate.includes(:hardware => :disks)` (3 queries)

This means the N+1 errors on the `VmOrTemplate` page go away.
