### PR TITLE
type_for_attribute fix

### DIFF
--- a/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
+++ b/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
@@ -2,7 +2,7 @@ RSpec::Matchers.define :have_virtual_attribute do |name, type|
   match do |klass|
     expect(klass.has_attribute?(name)).to be_truthy
     expect(klass.virtual_attribute?(name)).to be_truthy
-    expect(klass.type_for_attribute(name.to_s).type).to(eq(type))
+    expect(klass.type_for_attribute(name.to_s).type).to(eq(type)) if type
     klass.instance_methods.include?(name.to_sym)
   end
 

--- a/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
+++ b/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
@@ -2,7 +2,7 @@ RSpec::Matchers.define :have_virtual_attribute do |name, type|
   match do |klass|
     expect(klass.has_attribute?(name)).to be_truthy
     expect(klass.virtual_attribute?(name)).to be_truthy
-    expect(klass.type_for_attribute(name).type).to eq(type)
+    expect(klass.type_for_attribute(name.to_s).type).to(eq(type))
     klass.instance_methods.include?(name.to_sym)
   end
 

--- a/spec/have_virtual_attribute_spec.rb
+++ b/spec/have_virtual_attribute_spec.rb
@@ -3,8 +3,31 @@ describe "have_virtual_attribute" do
     expect(Author).to have_virtual_attribute(:nick_or_name, :string)
   end
 
-  it "understands non virtual attributes" do
+  it "detects virtual attribute failure" do
+    expect do
+      expect(Author).not_to have_virtual_attribute(:nick_or_name, :string)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /not have virtual column/)
+  end
+
+  it "detects incorrect type" do
+    expect(Author).not_to have_virtual_attribute(:nick_or_name, :integer)
+  end
+
+  it "detects incorrect type failure" do
+    expect do
+      expect(Author).to have_virtual_attribute(:nick_or_name, :integer)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /to have virtual column/)
+  end
+
+  it "detects virtual attribute" do
+    expect(Author).to have_virtual_attribute(:nick_or_name, :string)
+  end
+
+  it "detects an attribute is not virtual" do
     expect(Author).not_to have_virtual_attribute(:name, :string)
-    expect(Author).not_to have_virtual_attribute(:elephant)
+  end
+
+  it "detects missing virtual attribute" do
+    expect(Author).not_to have_virtual_attribute(:elephant, :string)
   end
 end

--- a/spec/have_virtual_attribute_spec.rb
+++ b/spec/have_virtual_attribute_spec.rb
@@ -1,10 +1,10 @@
 describe "have_virtual_attribute" do
   it "detects virtual attribute" do
-    expect(Author).to have_virtual_attribute(:nick_or_name)
+    expect(Author).to have_virtual_attribute(:nick_or_name, :string)
   end
 
   it "understands non virtual attributes" do
-    expect(Author).not_to have_virtual_attribute(:name)
+    expect(Author).not_to have_virtual_attribute(:name, :string)
     expect(Author).not_to have_virtual_attribute(:elephant)
   end
 end

--- a/spec/have_virtual_attribute_spec.rb
+++ b/spec/have_virtual_attribute_spec.rb
@@ -1,12 +1,16 @@
 describe "have_virtual_attribute" do
   it "detects virtual attribute" do
-    expect(Author).to have_virtual_attribute(:nick_or_name, :string)
+    expect(Author).to have_virtual_attribute(:nick_or_name)
   end
 
   it "detects virtual attribute failure" do
     expect do
-      expect(Author).not_to have_virtual_attribute(:nick_or_name, :string)
+      expect(Author).not_to have_virtual_attribute(:nick_or_name)
     end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /not have virtual column/)
+  end
+
+  it "detects virtual attribute with type" do
+    expect(Author).to have_virtual_attribute(:nick_or_name, :string)
   end
 
   it "detects incorrect type" do


### PR DESCRIPTION
`type_for_attribute` expects a string (not a symbol) in Rails 5.1 and before.
It allows a string or a symbol in Rails 5.2 and above.

This updates the spec to work in both Rails 5.1 and 5.2

It also adds spec coverage for the matcher