### PR TITLE
Version specific versions

### DIFF
--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -93,7 +93,11 @@ module ActiveRecord
           # change necessary for rails 5.0 and 5.1 - (changed/introduced in https://github.com/rails/rails/pull/31894)
           defaults = defaults.except(*virtual_attribute_names)
           # end change
-          @attributes_builder = ActiveRecord::AttributeSet::Builder.new(attribute_types, defaults)
+          @attributes_builder = if ActiveRecord.version.to_s >= "5.2"
+                                  ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
+                                else
+                                  ActiveRecord::AttributeSet::Builder.new(attribute_types, defaults)
+                                end
         end
         @attributes_builder
       end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -183,8 +183,11 @@ module ActiveRecord
           additional_attributes = result_set.first.keys
                                             .reject { |k| join_dep_keys.include?(k) }
                                             .reject { |k| join_root_aliases.include?(k) }
-                                            .map    { |k| [k, k] }
-          column_aliases += additional_attributes
+          column_aliases += if ActiveRecord.version.to_s < "6.0"
+                              additional_attributes.map { |k| [k, k] }
+                            else
+                              additional_attributes.map { |k| Aliases::Column.new(k, k) }
+                            end
         end
         # End of New Code
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -199,7 +199,11 @@ module ActiveRecord
           result_set.each { |row_hash|
             parent_key = primary_key ? row_hash[primary_key] : row_hash
             parent = parents[parent_key] ||= join_root.instantiate(row_hash, column_aliases, &block)
-            construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
+            if ActiveRecord.version.to_s < "6.0"
+              construct(parent, join_root, row_hash, result_set, seen, model_cache, aliases)
+            else
+              construct(parent, join_root, row_hash, seen, model_cache)
+            end
           }
         end
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -238,7 +238,7 @@ module ActiveRecord
         # it does not add an as() if the column already has an as
         # this code is based upon _select()
         fields = fields.flatten.map! do |field|
-          if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as)
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as) && !arel.kind_of?(Arel::Nodes::As)
             arel.as(connection.quote_column_name(field.to_s))
           else
             field


### PR DESCRIPTION
Class names change across different active record versions.

This adds case statements to handle these types of changes across active record 5.2 and 6.0

This is extracted out of #39