### PR TITLE
Put version check around calculate monkey patch

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -263,14 +263,13 @@ module ActiveRecord
 
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
-        # work around 1 until https://github.com/rails/rails/pull/25304 gets merged
-        # This allows attribute_name to be a virtual_attribute
-        if (arel = klass.arel_attribute(attribute_name)) && virtual_attribute?(attribute_name)
-          attribute_name = arel
+        if ActiveRecord.version.to_s < "5.1"
+          if (arel = klass.arel_attribute(attribute_name)) && virtual_attribute?(attribute_name)
+            attribute_name = arel
+          end
         end
-        # end work around 1
 
-        # allow calculate to work when including a virtual attribute
+        # allow calculate to work with includes and a virtual attribute
         real = without_virtual_includes
         return super if real.equal?(self)
 

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -82,9 +82,7 @@ module VirtualAttributes
                 if rel.loaded?
                   rel.blank? ? nil : (rel.map { |t| t.send(column).to_i } || 0).send(method_name)
                 else
-                  # aggregates are not smart enough to handle virtual attributes
-                  arel_column = rel.klass.arel_attribute(column)
-                  rel.try(method_name, arel_column) || 0
+                  rel.try(method_name, column) || 0
                 end
               end
           end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -96,6 +96,10 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.includes(:books => {:author_name => {}})).to preload_values(:first_book_author_name, author_name)
       expect(Author.includes(Author.virtual_includes(:first_book_author_name))).to preload_values(:first_book_author_name, author_name)
     end
+
+    it "counts" do
+      expect { expect(Author.includes(:books => :author_name).count).to eq(1) }.not_to raise_error
+    end
   end
 
   # references follow a different path than just includes
@@ -189,6 +193,10 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect { Author.includes(:books => [:invalid]).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
       expect { Author.includes(:books => {:invalid => {}}).references(:books).load }.to raise_error(ActiveRecord::ConfigurationError)
     end
+
+    it "counts" do
+      expect { expect(Author.includes(:books => :author_name).references(:books).count).to eq(1) }.not_to raise_error
+    end
   end
 
   context "preloads virtual_attribute with select.includes.references" do
@@ -199,7 +207,9 @@ describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
   it "preloads virtual_attribute in :include when :conditions are also present in calculations" do
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.name = '#{author_name}'")).to preload_values(:author_name, author_name)
+    expect(Book.includes([:author_name, :author]).references(:author).where(:authors => {:name => author_name})).to preload_values(:author_name, author_name)
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.id IS NOT NULL")).to preload_values(:author_name, author_name)
+    expect(Book.includes([:author_name, :author]).references(:author).where.not(:authors => {:id => nil})).to preload_values(:author_name, author_name)
   end
 
   context "preload virtual_attribute with preload" do

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -5,6 +5,30 @@ describe VirtualAttributes::VirtualTotal do
     Bookmark.delete_all
   end
 
+  describe "calculate" do
+    before do
+      Author.create_with_books(2)
+      Author.create_with_books(3)
+    end
+
+    it "counts records" do
+      expect(Author.count).to eq(2)
+    end
+
+    it "counts records with includes" do
+      expect(Author.includes(:books).count).to eq(2)
+    end
+
+    it "calculates aggregate of virtual attribute" do
+      expect(Author.sum(:total_books)).to eq(5)
+    end
+
+    # # fails
+    # it "calculates aggregate of virtual attribute with includes" do
+    #   expect(Author.includes(:books).sum(:total_books)).to eq(5)
+    # end
+  end
+
   describe ".virtual_total" do
     context "with a standard has_many" do
       it "sorts by total attribute" do


### PR DESCRIPTION
In code, mark this monkey patch as an pre ActiveRecord 5.0 only patch.


1. Make the version of active record that we are patching more explicit
2. Add tests to properly test this code.
3. Remove code that does the same conversion twice

- [x] https://travis-ci.org/kbrock/manageiq-cross_repo/builds/596266507