### PR TITLE
Disable global rspec monkey patching

### DIFF
--- a/spec/have_virtual_attribute_spec.rb
+++ b/spec/have_virtual_attribute_spec.rb
@@ -1,4 +1,4 @@
-describe "have_virtual_attribute" do
+RSpec.describe "have_virtual_attribute" do
   it "detects virtual attribute" do
     expect(Author).to have_virtual_attribute(:nick_or_name)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
-  config.expose_dsl_globally = true
+  config.expose_dsl_globally = false
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/with_test_class.rb
+++ b/spec/support/with_test_class.rb
@@ -11,7 +11,7 @@ require 'active_record'
 #  end
 #  ```
 #
-shared_context 'with test_class', :with_test_class do
+RSpec.shared_context 'with test_class', :with_test_class do
   before do
     class TestClassBase < ActiveRecord::Base
       self.abstract_class = true

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveRecord::VirtualAttributes::VirtualFields do
+RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   context "TestClass", :with_test_class do
     it "should not have any virtual columns" do
       expect(TestClass.virtual_attribute_names).to be_empty

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_class do
+RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_class do
   # double purposing col1. It has an actual value in the child class
   let(:parent) { TestClass.create(:col1 => 4) }
 

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -1,4 +1,4 @@
-describe ActiveRecord::VirtualAttributes::VirtualIncludes do
+RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
   before do
     Author.destroy_all
     Book.destroy_all

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -1,4 +1,4 @@
-describe VirtualAttributes::VirtualTotal do
+RSpec.describe VirtualAttributes::VirtualTotal do
   before do
     Author.delete_all
     Book.delete_all


### PR DESCRIPTION
minor change but does not fill global namespace with a bunch of methods.


Trying to get rid of a `./bin/console` warning:

```
irb: warn: can't alias context from irb_context.
```

google suggested this change. While it did not solve the problem, it looked like a good idea anyway. So still putting this PR in.