### PR TITLE
Change select to work better with ActiveRecord 5.2/6.0

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -245,8 +245,12 @@ module ActiveRecord
         # it does not add an as() if the column already has an as
         # this code is based upon _select()
         fields = fields.flatten.map! do |field|
-          if virtual_attribute?(field) && (arel = klass.arel_attribute(field)) && arel.respond_to?(:as) && !arel.kind_of?(Arel::Nodes::As)
-            arel.as(connection.quote_column_name(field.to_s))
+          if virtual_attribute?(field) && (arel = klass.arel_attribute(field))
+            if arel.respond_to?(:as) && !arel.kind_of?(Arel::Nodes::As) && !arel.try(:alias)
+              arel.as(connection.quote_column_name(field.to_s))
+            else
+              arel
+            end
           else
             field
           end


### PR DESCRIPTION
pulled out https://github.com/ManageIQ/activerecord-virtual_attributes/pull/39

### Before:

Virtual attributes are converted to sql when calling `select(column_names)`

### After:

Virtual attributes are converted to sql when building the sql. This is the same place that regular virtual attributes are converted to sql.

### Note:

This is more complicated than I would have liked.
The same code converts select clauses and group by clauses.
While the select clause needs to have aliases, the grouping does not. So extra attributes were passed into the method to distinguish between the 2 use cases