### PR TITLE
Rewrite virtual_total attribute_arel

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -98,7 +98,7 @@ module VirtualAttributes
       end
 
       def virtual_aggregate_arel(reflection, method_name, column)
-        return unless reflection && reflection.macro == :has_many && !reflection.options[:through]
+        return unless reflection && reflection.macro == :has_many
 
         # need db access for the reflection join_keys, so delaying all this key lookup until call time
         lambda do |t|

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -343,8 +343,16 @@ RSpec.describe VirtualAttributes::VirtualTotal do
       expect(model_with_children(2).total_bookmarks).to eq(4)
     end
 
-    it "is not defined in sql" do
-      expect(base_model.attribute_supported_by_sql?(:total_bookmarks)).to be(false)
+    it "calculates totals in primary query" do
+      expect(base_model.attribute_supported_by_sql?(:total_bookmarks)).to be(true)
+
+      model_with_children(1) # 2 =  1 book  @ 2 bookmarks each
+      model_with_children(0) # 0
+      model_with_children(3) # 6 =  3 books @ 2 bookmarks each
+
+      expect do
+        expect(base_model.select(:id, :total_bookmarks).order(:total_bookmarks => :desc).map(&:total_bookmarks)).to eq([6, 2, 0])
+      end.to match_query_limit_of(1)
     end
 
     def model_with_children(count)


### PR DESCRIPTION
There are a number of places in miq where using a `virtual_total` would simplify our code base. But those spots required that `virtual_total` works with `has_many :through`

This adds support for a `virtual_total` with a relation that uses one or more `:through => model`.

### before

manually construct the arel for `virtual_total` attributes.
This required that we know a lot about scopes, `join_keys`, and other edge cases.

We also were not able to handle the edge case of having `:through => :model`

### after

Let Active Record construct the arel for `virtual_total` attributes. We then tweak the arel by remove the primary table from the sub query since the table is already in our primary query.

We now support any relation that rails supports, since we are letting rails do the work for us

- [ ] https://travis-ci.org/kbrock/manageiq-cross_repo/builds/600719235
- [ ] https://github.com/ManageIQ/manageiq/pull/19410 fix manageiq