### PR TITLE
Add tests for match_query_limit_of

### DIFF
--- a/spec/match_query_limit_of_spec.rb
+++ b/spec/match_query_limit_of_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "match_query_limit_of" do
+  it "detects correct query count" do
+    expect { Author.all.load }.to match_query_limit_of(1)
+  end
+
+  it "detects query count failure" do
+    expect do
+      expect { Author.all.load }.to match_query_limit_of(0)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /Expected 0 queries, got 1/i)
+  end
+
+  it "detects a negative count test" do
+    expect { Author.all.load }.not_to match_query_limit_of(0)
+  end
+
+  it "detects failure with a negative count test" do
+    expect do
+      expect { Author.all.load }.not_to match_query_limit_of(1)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /not to expect the block to execute 1 queries/i)
+  end
+end

--- a/spec/preload_values_spec.rb
+++ b/spec/preload_values_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe "preloads_values" do
+  before do
+    Author.destroy_all
+    Book.destroy_all
+    Author.create_with_books(3).books.first.create_bookmarks(2)
+  end
+
+  let(:author_name) { "foo" }
+  let(:book_name) { "bar" }
+
+  it "detects preloaded values" do
+    expect(Book.select(:author_name)).to preload_values(:author_name, [author_name, author_name, author_name])
+  end
+
+  it "detects preloaded values converts to array" do
+    expect(Book.select(:author_name)).to preload_values(:author_name, author_name)
+  end
+
+  it "detects not preloaded" do
+    expect do
+      expect(Book).to preload_values(:author_name, author_name)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, "Expected to preload author_name but executed 3 queries instead")
+  end
+
+  it "detects incorrect values" do
+    expect do
+      expect(Book.select(:author_name)).to preload_values(:author_name, "bogus")
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  it "detects not preloading values" do
+    expect(Book).not_to preload_values(:author_name, author_name)
+  end
+
+  # NOTE: was unsure if incorrect values met or failed the expectation
+  # went with the core of the expectation is preloading. but matching values trumps all
+  it "detects not preloading values (bad value)" do
+    expect do
+      expect(Book).not_to preload_values(:author_name, "bogus")
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  end
+
+  it "detects not preloading values failure" do
+    expect do
+      expect(Book.select(:author_name)).not_to preload_values(:author_name, author_name)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, "Unexpectedly preloaded author_name")
+  end
+end

--- a/spec/support/match_query_limit_of.rb
+++ b/spec/support/match_query_limit_of.rb
@@ -14,7 +14,7 @@ RSpec::Matchers.define :match_query_limit_of do |expected|
   end
 
   description do
-    "expect the block to execute certain number of queries"
+    "expect the block to execute #{@count} queries"
   end
 
   supports_block_expectations


### PR DESCRIPTION
goal: improve test coverage to make [code climate](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes/code?sort=test_coverage) even happier.

in the process, improved the failure message.