### PR TITLE
separate instantiate with monkey patch to simplify

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -140,7 +140,7 @@ module ActiveRecord
         column_aliases = aliases.column_aliases(join_root)
 
         # New Code
-        column_aliases += select_values_from_references(column_aliases, result_set) unless result_set.empty?
+        column_aliases += select_values_from_references(column_aliases, result_set) if result_set.present?
         # End of New Code
 
         message_bus = ActiveSupport::Notifications.instrumenter

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -191,7 +191,7 @@ module ActiveRecord
       #
       # This is because rails is trying to reduce the number of queries
       # needed to fetch all of the records in the include, so it grabs the
-      # columns for both of the tables together to do it.  Unfortuantely (or
+      # columns for both of the tables together to do it.  Unfortunately (or
       # fortunately... depending on how you look at it), it does not remove
       # any `.select` columns from the query that is run in the process, so
       # that is brought along for the ride, but never used when this method

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -607,13 +607,22 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
       end
 
       it "supports #includes with #references" do
-        vm     = TestClass.create
-        klass  = vm.class
+        klass  = TestClass
+        vm     = klass.create
         table  = klass.arel_table
         str_id = Arel::Nodes::NamedFunction.new("CAST", [table[:id].as("CHAR")]).as("str_id")
         result = klass.select(str_id).includes(:children => {}).references(:children)
 
         expect(result.first.attributes["str_id"]).to eq(vm.id.to_s)
+      end
+
+      it "supports #includes with #references and empty resultsets" do
+        klass  = TestClass
+        table  = klass.arel_table
+        str_id = Arel::Nodes::NamedFunction.new("CAST", [table[:id].as("CHAR")]).as("str_id")
+        result = klass.select(str_id).includes(:children => {}).references(:children)
+
+        expect(result.first).to be_blank
       end
     end
 


### PR DESCRIPTION
code climate is saying the code complexity is 14 (exceeds 11 allowed)

simply pulling out code into another method

removing a few RuboCop overrides that are no longer necessary after this change