### PR TITLE
Remove description from matchers

### DIFF
--- a/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
+++ b/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
@@ -13,10 +13,6 @@ RSpec::Matchers.define :have_virtual_attribute do |name, type|
   failure_message_when_negated do |klass|
     "expected #{klass.name} to not have virtual column #{name.inspect} with type #{type.inspect}"
   end
-
-  description do
-    "expect the object to have the virtual column"
-  end
 end
 
 RSpec::Matchers.alias_matcher(:have_virtual_column, :have_virtual_attribute)

--- a/spec/match_query_limit_of_spec.rb
+++ b/spec/match_query_limit_of_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe "match_query_limit_of" do
   it "detects failure with a negative count test" do
     expect do
       expect { Author.all.load }.not_to match_query_limit_of(1)
-    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /not to expect the block to execute 1 queries/i)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /Expect not to execute 1 queries/i)
   end
 end

--- a/spec/support/match_query_limit_of.rb
+++ b/spec/support/match_query_limit_of.rb
@@ -13,8 +13,8 @@ RSpec::Matchers.define :match_query_limit_of do |expected|
     "Expected #{expected} queries, got #{@count}"
   end
 
-  description do
-    "expect the block to execute #{@count} queries"
+  failure_message_when_negated do
+    "Expect not to execute #{expected} queries"
   end
 
   supports_block_expectations

--- a/spec/support/preload_values.rb
+++ b/spec/support/preload_values.rb
@@ -44,9 +44,5 @@ RSpec::Matchers.define :preload_values do |field, expected_values|
     "Unexpectedly preloaded #{@field}"
   end
 
-  description do
-    "Ensure the block preloads a value to test that includes() and variants work correctly"
-  end
-
   supports_block_expectations
 end


### PR DESCRIPTION
Matchers need `failure_message_when_negated` or `description`. Not both.

They read just a little better when both `failure_message`s are defined.

To be honest, removing `description` to increase code coverage in
code climate.