### PR TITLE
fix spec to remove raw sql deprecation warning

### DIFF
--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -778,7 +778,8 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
     end
 
     # testing the select, order, and where clauses
-    tc = TestClass.select("lower column").order(:"lower column").find_by(:"lower column" => "abc")
+    quoted_column_name = TestClass.connection.quote_column_name("lower column")
+    tc = TestClass.select("lower column").order(Arel.sql(quoted_column_name)).find_by(:"lower column" => "abc")
     expect(tc.send("lower column")).to eq("abc")
   end
 


### PR DESCRIPTION
Rails 5.2 has a deprecation warning for this spec.

```
DEPRECATION WARNING:
Dangerous query method (method whose arguments are used as raw SQL)
called with non-attribute argument(s): :"lower column".
Non-attribute arguments will be disallowed in Rails 6.0.
This method should not be called with user-provided values,
such as request parameters or model attributes.
Known-safe values can be passed by wrapping them in Arel.sql().
```