### PR TITLE
Rails 52 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,3 @@ before_script:
 - sh -c "if [ '$DB' = 'mysql2' ]; then mysql -e 'DROP DATABASE IF EXISTS virtual_attributes; CREATE DATABASE virtual_attributes;'; fi"
 after_script:
 - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
-jobs:
-  allow_failures:
-  - gemfile: gemfiles/gemfile_52.gemfile
-    env: DB=mysql2
-  - gemfile: gemfiles/gemfile_52.gemfile
-    env: DB=pg
-  - gemfile: gemfiles/gemfile_52.gemfile
-    env: DB=sqlite3

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -283,7 +283,8 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(preloaded(Author.all.to_a, :books => :author_name)).to preload_values(:first_book_author_name, author_name)
     end
 
-    if ActiveRecord.version.to_s >= "6.0"
+    if ActiveRecord.version.to_s >= "5.2"
+      # Note: this is non-standard 5.2. 5.2 has a bug that eats these invalid references. This code handles that case correctly
       it "catches errors" do
         expect { Author.includes(:invalid).load }.to raise_error(ActiveRecord::ConfigurationError)
         expect { Author.includes(:books => :invalid).load }.to raise_error(ActiveRecord::ConfigurationError)


### PR DESCRIPTION
Support for rails 5.2

Basically 5.2 is the same as 6.0

6.0 did add a `polymorphic_parent` parameter that is passed around a lot (not quite as many places as I wanted). This parameter allows rails to detect if an invalid reference is passed into `preload()`.

While 5.2 does just eats those errors, it ended up being easier to just add support for that in 5.2 than implement a completely different solution, just with that one parameter gone.

I copied across `preloaders_on` for 5.2. It is basically the same for rails 5.2 and 6.0, but again, the extra parameter made leaving this out a pain - so it has been included.

The real change was with `preloaders_for_reflection`
5.2 does not have that method, but it does have the inlined code in `preloaders_for_one`.
Rails 6.0 and 5.2 handle the return value from that block of code differently. They also have slightly different parameters calling into `run`.

So I ended up implementing different versions of that method for 6.0 and 5.2. If it weren't for the `run` method parameter, I did have an implementation that was the same across versions.

cross repo test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/97