### PR TITLE
work around attribute.name [5.2, 6.0]

### DIFF
--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -51,9 +51,9 @@ class Author < VirtualTotalTestBase
   end
 
   # a (local) virtual_attribute without a uses, but with arel
-  virtual_attribute :nick_or_name, :string do |t|
+  virtual_attribute :nick_or_name, :string, :arel => (lambda do |t|
     t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [t[:nickname], t[:name]]))
-  end
+  end)
 
   def first_book_name
     books.first.name

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -830,6 +830,36 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
     end
   end
 
+  describe ".select" do
+    it "supports virtual attributes" do
+      Author.select(:id, :nick_or_name).first
+    end
+  end
+
+  describe ".where" do
+    it "supports virtual attributes hash syntax" do
+      Author.where(:nick_or_name => "abc").first # fails
+    end
+
+    it "supports virtual attributes arel syntax" do
+      Author.where(Author.arel_attribute(:total_books).gt(5)).first
+    end
+  end
+
+  describe ".order" do
+    it "supports virtual attributes symbol" do
+      Author.order(:nick_or_name).first # fails
+    end
+
+    it "supports virtual attributes hash" do
+      Author.order(:nick_or_name => "ASC").first # fails
+    end
+
+    it "supports virtual attributes arel" do
+      Author.order(Author.arel_attribute(:nick_or_name)).first
+    end
+  end
+
   it "doesn't botch up the attributes", :with_test_class do
     tc = TestClass.select(:id, :str).find(TestClass.create(:str => "abc", :col1 => 55).id)
     expect(tc.attributes.size).to eq(2)

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -5,6 +5,28 @@ RSpec.describe VirtualAttributes::VirtualTotal do
     Bookmark.delete_all
   end
 
+  describe ".select" do
+    it "supports virtual_totals" do
+      Author.select(:id, :total_books).first
+    end
+  end
+
+  describe ".where" do
+    it "supports virtual_totals hash syntax" do
+      Author.where(:total_books => 5).first
+    end
+
+    it "supports virtual_totals arel syntax" do
+      Author.where(Author.arel_attribute(:total_books).gt(5)).first
+    end
+  end
+
+  describe ".order" do
+    it "supports virtual_totals" do
+      Author.order(:total_books).first
+    end
+  end
+
   describe "calculate" do
     before do
       Author.create_with_books(2)


### PR DESCRIPTION
Rails is now calling:
```
attribute = arel_attribute()
attribute.name
```

All of our `arel_attributes` return a grouping or an attribute

This change allows our return values from `arel_attributes`
to respond to `grouping.name`, so serialization information can be looked
up in rails.

I looked into deferring the call to `arel_attributes` in rails, but this
requires a change in the attribute handlers, which has been an exposed
interface for a while, so it is not possible.
I'm leaving as monkey patch stage.

We may want to look into getting closer to the attribute code

Not thrilled with this solution.
Can't subclass Grouping because class is hardcoded.
Can't subclass Attribute for same reason.

introduced by https://github.com/rails/rails/pull/32981
cross repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/105