### PR TITLE
Version check for grouping monkey patch

### DIFF
--- a/lib/active_record/virtual_attributes/arel_groups.rb
+++ b/lib/active_record/virtual_attributes/arel_groups.rb
@@ -1,6 +1,7 @@
 # this is from https://github.com/rails/arel/pull/435
 # this allows sorting and where clauses to work with virtual_attribute columns
-if defined?(Arel::Nodes::Grouping)
+# no longer needed for rails 6.0 and up (change was merged)
+if ActiveRecord.version.to_s < "6.0" && defined?(Arel::Nodes::Grouping)
   module Arel
     module Nodes
       class Grouping


### PR DESCRIPTION
We had a temporary patch for grouping while a pr was merged
It has been incorporated in rails 6.0, so updating the patch
to let us know this and when we can delete it

fixed in: https://github.com/rails/arel/pull/449

travis was not linking.
change: https://travis-ci.org/github/ManageIQ/activerecord-virtual_attributes/builds/669392260

since other are not running 6.0, no need for cross repo