### PR TITLE
fixed 5.2 double preload with a null record

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -179,9 +179,10 @@ module ActiveRecord
           # preloader.rb active record 6.0
           # changed:
           # different from 5.2. But not called outside these redefined methods here, so it works fine
+          # did add compact to fix a 5.2 double preload nil bug
           def grouped_records(orig_association, records, polymorphic_parent)
             h = {}
-            records.each do |record|
+            records.compact.each do |record|
               # each class can resolve virtual_{attributes,includes} differently
               association = record.class.replace_virtual_fields(orig_association)
               # 1 line optimization for single element array:

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -216,6 +216,19 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "preloads attribute (:uses => :book)" do
       expect(Author.preload(:total_books)).to preload_values(:total_books, 3)
     end
+
+    it "double preloads (with some nulls in the data)" do
+      Book.create
+
+      books = Book.order(:id).includes(:author).to_a
+      expect(books.last.author).to be_nil # the book just created does not have an author
+
+      # the second time preloading throws an error
+      preloader = ActiveRecord::Associations::Preloader.new
+      preloader.preload(books, :author => :books)
+
+      expect(books.size).to be(4)
+    end
   end
 
   context "preloads virtual_attribute with preloader" do


### PR DESCRIPTION
in 5.2, when we preload some values and the association has no record
then there will be a null in the preloaded values

if you call preloaded on these records, that null will freak

     NoMethodError:
       undefined method `replace_virtual_fields' for NilClass:Class
     # ./lib/active_record/virtual_attributes/virtual_fields.rb:187:in `block in grouped_records'

ASIDE:

in miq, spec/models/metric/ci_mixin/rollup_spec.rb:70 was failing with the above failure as it tried to preload the ems and one of the hosts had no ems_cluster