### PR TITLE
Display warnings for invalid attributes

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -190,8 +190,10 @@ module ActiveRecord
 
               case association
               when Symbol, String
+                # 4/24/20 we want to revert #67 once we handle all these error cases in our codebase.
                 reflection = record.class._reflect_on_association(association)
-                next if polymorphic_parent && !reflection || !record.association(association).klass
+                display_virtual_attribute_deprecation("#{record.class.name}.#{association} does not exist") if !reflection && !polymorphic_parent
+                next if !reflection || !record.association(association).klass
               when nil
                 next
               else # need parent (preloaders_for_{hash,one}) to handle this Array/Hash
@@ -202,6 +204,21 @@ module ActiveRecord
             h
           end
           # rubocop:enable Style/BlockDelimiters, Lint/AmbiguousBlockAssociation, Style/MethodCallWithArgsParentheses
+
+          def display_virtual_attribute_deprecation(str)
+            short_caller = caller
+            # if debugging is turned on, don't prune the backtrace.
+            # if debuggint is off, prune down to the line where the sql is executed
+            # this defaults to false and only displays 1 line number.
+            unless ActiveSupport::Deprecation.debug
+              bc = ActiveSupport::BacktraceCleaner.new
+              bc.add_silencer { |line| line =~ /virtual_fields/ }
+              bc.add_silencer { |line| line =~ /active_record/ }
+              short_caller = bc.clean(caller)
+            end
+
+            ActiveSupport::Deprecation.warn(str, short_caller)
+          end
         else
           def preloaders_for_one(association, records, scope)
             klass_map = records.compact.group_by(&:class)

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -297,13 +297,20 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     if ActiveRecord.version.to_s >= "5.2"
-      # Note: this is non-standard 5.2. 5.2 has a bug that eats these invalid references. This code handles that case correctly
-      it "catches errors" do
-        expect { Author.includes(:invalid).load }.to raise_error(ActiveRecord::ConfigurationError)
-        expect { Author.includes(:books => :invalid).load }.to raise_error(ActiveRecord::ConfigurationError)
+      # NOTE: ActiveSupport::Deprecation.debug = true will show the whole backtrace
+      it "deprecates invalid include" do
+        expect do
+          Author.preload(:invalid).load
+        end.to output(/DEPRECATION WARNING.*virtual_includes_spec/).to_stderr
+      end
+
+      it "deprecates invalid nested includes" do
+        expect do
+          Author.preload(:books => :invalid).load
+        end.to output(/DEPRECATION WARNING.*virtual_includes_spec/).to_stderr
       end
     else
-      it "ignores errors" do
+      it "ignores invalid includes" do
         expect { Author.includes(:invalid).load }.not_to raise_error
         expect { Author.includes(:books => :invalid).load }.not_to raise_error
       end


### PR DESCRIPTION
Display warnings for invalid attributes

before:
we were throwing errors, which is correct, but introducing this error checking causes
too many problems.

after:
The deprecation will give us time to fix the issues
in a more reasonable time period.
