### PR TITLE
no longer support invalid virtual_column calls

### DIFF
--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -48,13 +48,9 @@ module ActiveRecord
       #
 
       # Compatibility method: `virtual_attribute` is a more accurate name
-      def virtual_column(name, type_or_options, **options)
-        if type_or_options.kind_of?(Hash)
-          options = options.merge(type_or_options)
-          type = options.delete(:type)
-        else
-          type = type_or_options
-        end
+      def virtual_column(name, **options)
+        type = options.delete(:type)
+        raise ArgumentError, "missing :type attribute" unless type
 
         virtual_attribute(name, type, **options)
       end


### PR DESCRIPTION
The `virtual_column` method was sometimes called with a type instead of `:type =>`.
While this was never valid, it was prevalent enough to code a fix.

These have all been cleared up, and this PR officially drops support for the bad call.

we're dropping support because ruby 2.7 doesn't like
a hash and named keys right next to each other.

This removes the warning:

```
warning: Passing the keyword argument as the last hash parameter is deprecated
```

Fixes #70 

/cc @agrare https://github.com/ManageIQ/manageiq/issues/19678