### PR TITLE
Introduce aggregate methods for average, min, max

### DIFF
--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -27,7 +27,10 @@ class Author < VirtualTotalTestBase
            :class_name => "Book", :foreign_key => "author_id"
 
   virtual_total :total_recently_published_books, :recently_published_books
-  virtual_aggregate :sum_recently_published_books_rating, :recently_published_books, :sum, :rating
+  virtual_average :average_recently_published_books_rating, :recently_published_books, :rating
+  virtual_minimum :minimum_recently_published_books_rating, :recently_published_books, :rating
+  virtual_maximum :maximum_recently_published_books_rating, :recently_published_books, :rating
+  virtual_sum :sum_recently_published_books_rating, :recently_published_books, :rating
   virtual_delegate :description, :to => :current_photo, :prefix => true
 
   # This is here to provide a virtual_total of a virtual_has_many that depends upon an array of associations.

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -579,6 +579,12 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           end.to_not make_database_queries
         end
       end
+
+      it "orders by values with a nil (having the nil (defaulted to 0) first" do
+        authors
+        query = Author.order(:sum_recently_published_books_rating)
+        expect(query.map(&:id)).to eq([author3, author4, author2, author].map(&:id))
+      end
     end
   end
 end

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -435,43 +435,150 @@ RSpec.describe VirtualAttributes::VirtualTotal do
       let(:author3) { Author.create }
       let(:author4) { Author.create.tap { |a| a.create_books(1, :published => true) } }
 
-      # NOTE: rails converts the nil to a 0
-      it "calculates sum with one off query" do
-        authors
+      describe ":sum" do
+        # NOTE: rails converts the nil to a 0
+        it "calculates sum with one off query" do
+          authors
 
-        expect do
-          expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-        end.to make_database_queries(:count => 4)
+          expect do
+            expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
+          end.to make_database_queries(:count => 4)
+        end
+
+        it "calculates sum from preloaded association" do
+          authors.each { |a| a.recently_published_books.load }
+
+          expect do
+            expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, nil])
+          end.to_not make_database_queries
+        end
+
+        it "calculates sum from attribute" do
+          authors
+          query = Author.select(:id, :sum_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
+          end.to_not make_database_queries
+        end
+
+        it "calculates sum from attribute (and preloaded association)" do
+          authors
+          query = Author.includes(:recently_published_books).select(:id, :sum_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
+          end.to_not make_database_queries
+        end
+
+        it "orders by values with a nil (having the nil (defaulted to 0) first" do
+          authors
+          query = Author.order(:sum_recently_published_books_rating)
+          expect(query.map(&:id)).to eq([author3, author4, author2, author].map(&:id))
+        end
       end
 
-      it "calculates sum from preloaded association" do
-        authors.each { |a| a.recently_published_books.load }
+      describe ":average" do
+        # NOTE: rails converts the nil to a 0
+        it "calculates avg with one off query" do
+          authors
 
-        expect do
-          expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-        end.to_not make_database_queries
+          expect do
+            expect(authors.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
+          end.to make_database_queries(:count => 4)
+        end
+
+        it "calculates avg from preloaded association" do
+          authors.each { |a| a.recently_published_books.load }
+
+          expect do
+            expect(authors.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
+          end.to_not make_database_queries
+        end
+
+        it "calculates avg from attribute" do
+          authors
+          query = Author.select(:id, :average_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
+          end.to_not make_database_queries
+        end
+
+        it "calculates avg from attribute (and preloaded association)" do
+          authors
+          query = Author.includes(:recently_published_books).select(:id, :average_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
+          end.to_not make_database_queries
+        end
       end
 
-      it "calculates sum from attribute" do
-        authors
-        query = Author.select(:id, :sum_recently_published_books_rating).order(:id).load
-        expect do
-          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-        end.to make_database_queries(:count => 0)
+      describe ":maximum" do
+        # NOTE: rails converts the nil to a 0
+        it "calculates max with one off query" do
+          authors
+
+          expect do
+            expect(authors.map(&:maximum_recently_published_books_rating)).to eq([4, 5, 0, 0])
+          end.to make_database_queries(:count => 4)
+        end
+
+        it "calculates max from preloaded association" do
+          authors.each { |a| a.recently_published_books.load }
+
+          expect do
+            expect(authors.map(&:maximum_recently_published_books_rating)).to eq([4, 5, nil, nil])
+          end.to_not make_database_queries
+        end
+
+        it "calculates max from attribute" do
+          authors
+          query = Author.select(:id, :maximum_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:maximum_recently_published_books_rating)).to eq([4, 5, 0, 0])
+          end.to_not make_database_queries
+        end
+
+        it "calculates max from attribute (and preloaded association)" do
+          authors
+          query = Author.includes(:recently_published_books).select(:id, :maximum_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:maximum_recently_published_books_rating)).to eq([4, 5, 0, 0])
+          end.to_not make_database_queries
+        end
       end
 
-      it "calculates sum from attribute (and preloaded association)" do
-        authors
-        query = Author.includes(:recently_published_books).select(:id, :sum_recently_published_books_rating).order(:id).load
-        expect do
-          expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-        end.to_not make_database_queries
-      end
+      describe ":minimum" do
+        # NOTE: rails converts the nil to a 0
+        it "calculates min with one off query" do
+          authors
 
-      it "orders by values with a nil (having the nil (defaulted to 0) first" do
-        authors
-        query = Author.order(:sum_recently_published_books_rating)
-        expect(query.map(&:id)).to eq([author3, author4, author2, author].map(&:id))
+          expect do
+            expect(authors.map(&:minimum_recently_published_books_rating)).to eq([2, 5, 0, 0])
+          end.to make_database_queries(:count => 4)
+        end
+
+        it "calculates min from preloaded association" do
+          authors.each { |a| a.recently_published_books.load }
+
+          expect do
+            expect(authors.map(&:minimum_recently_published_books_rating)).to eq([2, 5, nil, nil])
+          end.to_not make_database_queries
+        end
+
+        it "calculates min from attribute" do
+          authors
+          query = Author.select(:id, :minimum_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:minimum_recently_published_books_rating)).to eq([2, 5, 0, 0])
+          end.to_not make_database_queries
+        end
+
+        it "calculates min from attribute (and preloaded association)" do
+          authors
+          query = Author.includes(:recently_published_books).select(:id, :minimum_recently_published_books_rating).order(:id).load
+          expect do
+            expect(query.map(&:minimum_recently_published_books_rating)).to eq([2, 5, 0, 0])
+          end.to_not make_database_queries
+        end
       end
     end
   end

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -480,7 +480,6 @@ RSpec.describe VirtualAttributes::VirtualTotal do
         # NOTE: rails converts the nil to a 0
         it "calculates avg with one off query" do
           authors
-
           expect do
             expect(authors.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
           end.to make_database_queries(:count => 4)


### PR DESCRIPTION
blocked by:

- [x] https://github.com/ManageIQ/activerecord-virtual_attributes/pull/15 

adding `virtual_average`, `virtual_minimum`, `virtual_maximum` to the work started about a year ago that handles the nil/0 discrepancy where ActiveRecord/ruby treat the sum of no rows as 0 while SQL treats it as null
