### PR TITLE
fix typo in virtual aggregate guard clause

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -53,7 +53,7 @@ module VirtualAttributes
       #    # arel => (SELECT sum("disks"."size") where "hardware"."id" = "disks"."hardware_id")
 
       def virtual_aggregate(name, relation, method_name = :sum, column = nil, options = {})
-        return define_virtual_total(name, relation, options) if method_name == :size
+        return virtual_total(name, relation, options) if method_name == :size
 
         define_virtual_aggregate_method(name, relation, method_name, column)
         define_virtual_aggregate_attribute(name, relation, method_name, column, options)


### PR DESCRIPTION
At this time, there is a different method virtual_total
that does count/size. this guard clause calls that other method for the user

We have changed all our code to use the proper `virtual_total` calls, hence we didn't get caught by this error. we are keeping this for safety reasons.
