### PR TITLE
Fix delegates to start respecting polymorphic associations 

### DIFF
--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -3,37 +3,34 @@
 ActiveRecord::Schema.define(:version => 0) do
   self.verbose = false
 
-  # tables for virtual totals
   create_table "authors", :force => true do |t|
     t.string   "name"
     t.string   "nickname"
   end
 
   create_table "books", :force => true do |t|
-    t.integer  "author_id"
-    t.string   "author_type", :default => "Author"
-    t.string   "name"
-    t.boolean  "published", :default => false
-    t.boolean  "special",   :default => false
-    t.integer  "rating"
-    t.datetime "created_on"
+    t.references "author", :index => true
+    t.string     "author_type", :default => "Author"
+    t.string     "name"
+    t.boolean    "published", :default => false
+    t.boolean    "special",   :default => false
+    t.integer    "rating"
+    t.datetime   "created_on"
   end
-  add_index "books", "author_id"
-  # add_foreign_key("books", "authors", :column => "author_id")
 
   create_table "bookmarks", :force => true do |t|
-    t.integer  "book_id"
-    t.string   "name"
-    t.datetime "created_on"
+    t.references "book", :index => true
+    t.string     "name"
+    t.datetime   "created_on"
   end
-  add_index "bookmarks", "book_id"
-  # add_foreign_key("bookmarks", "books", :column => "book_id")
 
-  create_table "authors_books", :force => true do |t|
-    t.integer "author_id"
-    t.integer "book_id"
+  create_join_table "authors", "books", :force => true do |t|
+    t.index "author_id"
+    t.index "book_id"
   end
-  add_index "authors_books", "author_id"
-  add_index "authors_books", "book_id"
+
+  create_table "photos", :force => true do |t|
+    t.references "imageable", :polymorphic => true
+    t.string "description"
+  end
 end
-

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -234,4 +234,16 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       expect { model.new }.to raise_error(NameError)
     end
   end
+
+  context "with polymorphic has_one" do
+    it "respects type" do
+      author = Author.create(:name => "no one of consequence")
+      book = author.books.create(:name => "nothing of consequence", :id => author.id)
+      author.photos.create(:description => 'good')
+      book.photos.create(:description => 'bad')
+
+      author = Author.select(:id, :current_photo_description).find(author.id)
+      expect(author.current_photo_description).to eq("good")
+    end
+  end
 end


### PR DESCRIPTION
Before:

virtual delegates does not include the `type` column when fetching associated models.

So if a model has a polymorphic relationship (e.g. points to either books or authors), it would bring back extra records(e.g. books with author ids or authors with book ids).

It is a little bit of an edge case, and that is why this bug was not found until now. But since all tables start with an id of 1, the overlap can happen all the time.

In this case, you have to delegate from the has one side to the belongs to, which is uncommon for us and was not even possible before nick added the `limit()` and `order()` fixes.

In the bz example, the has_one only brings back one record, and it brought back a record with an id from a different class. So the limit (has one limits to one) brought back the wrong record.

After:

It properly constrains the records to the correct type.

Changes:

- test model has a new association
- test schema uses `references`
- test model has comments around use cases

I had looked into using `AssociationScope.scope` instead. It was very close, but is a much bigger change and would require a bit of monkey patching.

https://bugzilla.redhat.com/show_bug.cgi?id=1704644
https://github.com/ManageIQ/manageiq/issues/20115
https://github.com/ManageIQ/manageiq/pull/20494

/cc @NickLaMuro I'm changing the other va stuff as you read this