### PR TITLE
drop support for AR sub five dot two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
 - DB=pg
 - DB=sqlite3
 gemfile:
-- gemfiles/gemfile_50.gemfile
-- gemfiles/gemfile_51.gemfile
 - gemfiles/gemfile_52.gemfile
 - gemfiles/gemfile_60.gemfile
 before_install:

--- a/Appraisals
+++ b/Appraisals
@@ -1,23 +1,8 @@
-%w(5.0.7 5.1.7 5.2.3 6.0.0).each do |ar_version|
+%w(5.2.3 6.0.0).each do |ar_version|
   appraise "gemfile-#{ar_version.split('.').first(2).join}" do
     gem "activerecord", "~> #{ar_version}"
-
-    if ar_version >= "5.0"
       gem "mysql2"
-    elsif ar_version >= "4.2"
-      gem "mysql2", "~> 0.4.0"
-    end
-
-    if ar_version >= "5.0"
       gem "pg"
-    else
-      gem "pg", "0.18.4"
-    end
-
-    if ar_version >= "5.2"
       gem "sqlite3"
-    else
-      gem "sqlite3", "~> 1.3.13"
-    end
   end
 end

--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -89,11 +89,7 @@ module ActiveRecord
           # change necessary for rails 5.0 and 5.1 - (changed/introduced in https://github.com/rails/rails/pull/31894)
           defaults = defaults.except(*virtual_attribute_names)
           # end change
-          @attributes_builder = if ActiveRecord.version.to_s >= "5.2"
-                                  ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
-                                else
-                                  ActiveRecord::AttributeSet::Builder.new(attribute_types, defaults)
-                                end
+          @attributes_builder = ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
         end
         @attributes_builder
       end
@@ -129,20 +125,6 @@ require "active_record/virtual_attributes/virtual_fields"
 #
 # Class extensions
 #
-
-# this patch is no longer necessary for 5.2
-if ActiveRecord.version.to_s < "5.2"
-  require "active_record/attribute"
-  module ActiveRecord
-    # This is a bug in rails 5.0 and 5.1, but it is made much worse by virtual attributes
-    class Attribute
-      def with_value_from_database(value)
-        # self.class.from_database(name, value, type)
-        initialized? ? self.class.from_database(name, value, type) : self
-      end
-    end
-  end
-end
 
 require "active_record/virtual_attributes/virtual_total"
 require "active_record/virtual_attributes/arel_groups"

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -151,11 +151,7 @@ module ActiveRecord
           # There is currently no way to propagate sql over a virtual association
           if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
             lambda do |t|
-              join_keys = if ActiveRecord.version.to_s >= "5.1"
-                            to_ref.join_keys
-                          else
-                            to_ref.join_keys(to_ref.klass)
-                          end
+              join_keys = to_ref.join_keys
               src_model_id = arel_attribute(join_keys.foreign_key, t)
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
               VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -438,12 +438,6 @@ module ActiveRecord
 
       # From ActiveRecord::Calculations
       def calculate(operation, attribute_name)
-        if ActiveRecord.version.to_s < "5.1"
-          if (arel = klass.arel_attribute(attribute_name)) && virtual_attribute?(attribute_name)
-            attribute_name = arel
-          end
-        end
-
         # allow calculate to work with includes and a virtual attribute
         real = without_virtual_includes
         return super if real.equal?(self)


### PR DESCRIPTION
since we're on 5.2, do we need to keep the 5.1 code?

... eventually...