### PR TITLE
remove sudo:false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon.`