### PR TITLE
remove sudo:false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
we no longer need `sudo: false` per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

@miq-bot assign @kbrock 
