### PR TITLE
rename AlignHash cop

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -248,7 +248,7 @@ module ActiveRecord
     # syntax from the original codebase.
     #
     # rubocop:disable Style/BlockDelimiters, Layout/SpaceAfterComma, Style/HashSyntax
-    # rubocop:disable Layout/AlignHash
+    # rubocop:disable Layout/HashAlignment
     class JoinDependency
       def instantiate(result_set, *_, &block)
         primary_key = aliases.column_alias(join_root, join_root.primary_key)
@@ -289,7 +289,7 @@ module ActiveRecord
         parents.values
       end
       # rubocop:enable Style/BlockDelimiters, Layout/SpaceAfterComma, Style/HashSyntax
-      # rubocop:enable Layout/AlignHash
+      # rubocop:enable Layout/HashAlignment
 
       #
       # This monkey patches the ActiveRecord::Associations::JoinDependency to


### PR DESCRIPTION
the 0.77 rubocop release standardized some of the cop names
in order for this disable line to work, we probably want to rename to match

as a **completely irrelevant** note, the automation engine repo never re-enables these cops when we do this trick there: 
`# rubocop:disable Naming/MethodParameterName` never has a matching enable line on any of the three occurrences 

<sub><sup>136/365 = 0.3726</sub></sup>