### PR TITLE
[wip] arel_attribute is deprecated in 6.1

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_arel.rb
+++ b/lib/active_record/virtual_attributes/virtual_arel.rb
@@ -31,7 +31,7 @@ module ActiveRecord
               arel
             end
           else
-            super
+            arel_table[column_name]
           end
         end
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -376,7 +376,7 @@ module ActiveRecord
         if select_values.any?
           arel.project(*arel_columns(select_values.uniq, true))
         elsif klass.ignored_columns.any?
-          arel.project(*klass.column_names.map { |field| arel_attribute(field) })
+          arel.project(*klass.column_names.map { |field| arel_table[field] })
         else
           arel.project(table[Arel.star])
         end
@@ -406,7 +406,7 @@ module ActiveRecord
         from = from_clause.name || from_clause.value
 
         if klass.columns_hash.key?(field) && (!from || table_name_matches?(from))
-          arel_attribute(field)
+          arel_table[field]
         elsif virtual_attribute?(field)
           virtual_attribute_arel_column(field, allow_alias, &block)
         else
@@ -415,7 +415,7 @@ module ActiveRecord
       end
 
       def virtual_attribute_arel_column(field, allow_alias)
-        arel = arel_attribute(field)
+        arel = arel_table[field]
         if arel.nil?
           yield field
         elsif allow_alias && arel && arel.respond_to?(:as) && !arel.kind_of?(Arel::Nodes::As) && !arel.try(:alias)

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -28,7 +28,8 @@ class Database
   def migrate
     ActiveRecord::Migration.verbose = false
     ActiveRecord::Base.configurations = YAML.load(ERB.new(IO.read("#{dirname}/database.yml")).result)
-    ActiveRecord::Base.establish_connection ActiveRecord::Base.configurations[adapter]
+    ActiveRecord::Base.establish_connection ActiveRecord::Base.configurations.configs_for(:name => adapter)
+
 
     require "#{dirname}/schema"
     require "#{dirname}/models"


### PR DESCRIPTION
`arel_table` is suggested instead of `arel_attribute`

`DEPRECATION WARNING: arel_attribute is deprecated and will be removed from Rails 6.2`

is for future, requires the prior merge of the other two open prs 

is work in progress because the line I have here for the config deprecation warning isn't correct:


the configurations deprecation warning: 
`ActiveRecord::Base.configurations` now uses `configs_for`: we're not supposed to "...call methods on the `configurations` hash directly..." (see https://github.com/rails/rails/pull/33637)
```
    def default_hash(env = default_env)
      default = find_db_config(env)
      default.configuration_hash if default
    end
    alias :[] :default_hash
    deprecate "[]": "Use configs_for", default_hash: "Use configs_for"
```