### PR TITLE
Rails 5.2 changes (many needed for 6.1 support)

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "db-query-matchers"
+  spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
-  spec.add_development_dependency "manageiq-style"
 end

--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "db-query-matchers", "~>0.10"
+  spec.add_development_dependency "db-query-matchers"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", ">= 0.21.2"

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -151,10 +151,9 @@ module ActiveRecord
           # There is currently no way to propagate sql over a virtual association
           if reflect_on_association(to_ref.name) && (to_ref.macro == :has_one || to_ref.macro == :belongs_to)
             lambda do |t|
-              join_keys = to_ref.join_keys
-              src_model_id = arel_attribute(join_keys.foreign_key, t)
+              src_model_id = arel_attribute(to_ref.join_foreign_key, t)
               blk = ->(arel) { arel.limit = 1 } if to_ref.macro == :has_one
-              VirtualDelegates.select_from_alias(to_ref, col, join_keys.key, src_model_id, &blk)
+              VirtualDelegates.select_from_alias(to_ref, col, to_ref.join_primary_key, src_model_id, &blk)
             end
           end
         end

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -260,6 +260,7 @@ module ActiveRecord
 
         yield arel if block_given?
 
+        # convert arel to sql to populate with bind variables
         Arel.sql("(#{arel.to_sql})")
       end
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -115,7 +115,7 @@ module ActiveRecord
               super(reflection, records, scope)
             end
           end
-        elsif ActiveRecord.version.to_s >= "5.2" # < 6.0
+        else
           # preloader.rb active record 6.0
           # else block changed to reflect how 5.2 preloaders_for_one works
           def preloaders_for_reflection(reflection, records, scope, polymorphic_parent)
@@ -218,24 +218,6 @@ module ActiveRecord
             end
 
             ActiveSupport::Deprecation.warn(str, short_caller)
-          end
-        else
-          def preloaders_for_one(association, records, scope)
-            klass_map = records.compact.group_by(&:class)
-
-            # new logic: preload virtual fields / virtual includes
-            loaders = klass_map.keys.group_by { |klass| klass.virtual_includes(association) }.flat_map do |virtuals, klasses|
-              subset = klasses.flat_map { |klass| klass_map[klass] }
-              preload(subset, virtuals)
-            end
-            # /new logic
-
-            records_with_association = klass_map.select { |k, _rs| k.reflect_on_association(association) }.flat_map { |_k, rs| rs }
-            if records_with_association.any?
-              loaders.concat(super(association, records_with_association, scope))
-            end
-
-            loaders
           end
         end
       })

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -190,10 +190,8 @@ module ActiveRecord
 
               case association
               when Symbol, String
-                # 4/24/20 we want to revert #67 once we handle all these error cases in our codebase.
                 reflection = record.class._reflect_on_association(association)
-                display_virtual_attribute_deprecation("#{record.class.name}.#{association} does not exist") if !reflection && !polymorphic_parent
-                next if !reflection || !record.association(association).klass
+                next if polymorphic_parent && !reflection || !record.association(association).klass
               when nil
                 next
               else # need parent (preloaders_for_{hash,one}) to handle this Array/Hash
@@ -204,21 +202,6 @@ module ActiveRecord
             h
           end
           # rubocop:enable Style/BlockDelimiters, Lint/AmbiguousBlockAssociation, Style/MethodCallWithArgsParentheses
-
-          def display_virtual_attribute_deprecation(str)
-            short_caller = caller
-            # if debugging is turned on, don't prune the backtrace.
-            # if debugging is off, prune down to the line where the sql is executed
-            # this defaults to false and only displays 1 line number.
-            unless ActiveSupport::Deprecation.debug
-              bc = ActiveSupport::BacktraceCleaner.new
-              bc.add_silencer { |line| line =~ /virtual_fields/ }
-              bc.add_silencer { |line| line =~ /active_record/ }
-              short_caller = bc.clean(caller)
-            end
-
-            ActiveSupport::Deprecation.warn(str, short_caller)
-          end
         end
       })
     end

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -151,4 +151,4 @@ module VirtualAttributes
   end
 end
 
-ActiveRecord::Base.send(:include, VirtualAttributes::VirtualTotal)
+ActiveRecord::Base.include VirtualAttributes::VirtualTotal

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
 
       it "with arel" do
         TestClass.virtual_column :vcol1, :type => :boolean, :arel => ->(t) { t.grouping(t[:vcol].lower) }
-        expect(TestClass.arel_attribute("vcol1").to_sql).to match(/LOWER\(["`]test_classes["`].["`]vcol["`]\)/)
+        expect(TestClass.select("vcol1").to_sql).to match(/LOWER\(["`]test_classes["`].["`]vcol["`]\)/)
       end
 
       it "can have multiple virtual columns defined by string or symbol" do

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -307,26 +307,6 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "uses preloaded fields" do
       expect(preloaded(Author.all.to_a, :books => :author_name)).to preload_values(:first_book_author_name, author_name)
     end
-
-    if ActiveRecord.version.to_s >= "5.2"
-      # NOTE: ActiveSupport::Deprecation.debug = true will show the whole backtrace
-      it "deprecates invalid include" do
-        expect do
-          Author.preload(:invalid).load
-        end.to output(/DEPRECATION WARNING.*virtual_includes_spec/).to_stderr
-      end
-
-      it "deprecates invalid nested includes" do
-        expect do
-          Author.preload(:books => :invalid).load
-        end.to output(/DEPRECATION WARNING.*virtual_includes_spec/).to_stderr
-      end
-    else
-      it "ignores invalid includes" do
-        expect { Author.includes(:invalid).load }.not_to raise_error
-        expect { Author.includes(:books => :invalid).load }.not_to raise_error
-      end
-    end
   end
 
   context "preloads virtual_reflection with includes" do

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -200,6 +200,18 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
   end
 
   context "preloads virtual_attribute with select.includes.references" do
+    # select().references().includes() for a single field never worked well together.
+    #
+    # brings back column (author_name) in subselect
+    # brings back (via joins and selects) author record
+    #
+    # issues:
+    #
+    # 1. It brings back authors table for no reason. The author_name subselect is plenty.
+    # 2. The main query SELECT does not have author_id which is needed to join to the authors table.
+    #
+    # rails 6.0 brings back all of books.*, authors.*, so the query works
+    # rails 6.1 brings back books.id, authors.*, (missing author_id) and blows up.
     it "preloads virtual_attribute (:uses => {:book => :author_name})" do
       expect(Book.select(:author_name).includes(:author_name).references(:author_name)).to preload_values(:author_name, author_name)
     end
@@ -467,9 +479,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
   end
 
   context "supports left_joins with virtual attributes" do
-    it "doesn't freak when virtual attribute in " do
-      # sorry, :author_name will not be available
-      # in that case, just .where.not(:author_name => nil) - no need for left_joins
+    it "supports virtual includes in left joins" do
       expect { Book.left_joins(:author_name).where.not(:authors => {:name => nil}).load }.not_to raise_error
     end
   end


### PR DESCRIPTION
Lots of comment changes.
Some deprecations of rails 5.1 behavior

A few quick hits that are needed for rails 6.1 support.

commits: 

- stop using join_keys 
- comments to understand what changed in the cod
- more drop rails 5.1 changes
- drop deprecation warnings when associations are invalid 
- allow more recent versions of db query matchers (dev only)
- remove unneeded Arel::Attribute.to_sql 
- alphabetize gemspec
- remove send(:include) 


