### PR TITLE
Auto add grouping

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_arel.rb
+++ b/lib/active_record/virtual_attributes/virtual_arel.rb
@@ -56,7 +56,8 @@ module ActiveRecord
           return unless arel_lambda
 
           arel = arel_lambda.call(table)
-          arel.name = column_name if arel.kind_of?(Arel::Nodes::Grouping)
+          arel = Arel::Nodes::Grouping.new(arel) unless arel.kind_of?(Arel::Nodes::Grouping)
+          arel.name = column_name
           arel
         end
 

--- a/lib/active_record/virtual_attributes/virtual_arel.rb
+++ b/lib/active_record/virtual_attributes/virtual_arel.rb
@@ -9,6 +9,8 @@ module ActiveRecord
     #
     # Model.select(Model.arel_table.grouping(Model.arel_table[:field2]).as(:field))
     # Model.attribute_supported_by_sql?(:field) # => true
+
+    # in essence, this is our Arel::Nodes::VirtualAttribute
     class Arel::Nodes::Grouping
       attr_accessor :name
     end
@@ -22,20 +24,17 @@ module ActiveRecord
       end
 
       module ClassMethods
+        # Overriding rails method
         def arel_attribute(column_name, arel_table = self.arel_table)
           load_schema
           if virtual_attribute?(column_name) && !attribute_alias?(column_name)
-            if (col = _virtual_arel[column_name.to_s])
-              arel = col.call(arel_table)
-              arel.name = column_name if arel.kind_of?(Arel::Nodes::Grouping)
-              arel
-            end
+            arel_for_virtual_attribute(column_name, arel_table)
           else
             super
           end
         end
 
-        # supported by sql if
+        # supported by sql if any are true:
         # - it is an attribute alias
         # - it is an attribute that is non virtual
         # - it is an attribute that is virtual and has arel defined
@@ -45,9 +44,25 @@ module ActiveRecord
             (has_attribute?(name) && (!virtual_attribute?(name) || !!_virtual_arel[name.to_s]))
         end
 
+        # private api
+        #
+        # @return [Nil|Arel::Nodes::Grouping]
+        #   for virtual attributes:
+        #       returns the arel for the column
+        #   for non sql friendly virtual attributes:
+        #       returns nil        
+        def arel_for_virtual_attribute(column_name, table) # :nodoc:
+          arel_lambda = _virtual_arel[column_name.to_s]
+          return unless arel_lambda
+
+          arel = arel_lambda.call(table)
+          arel.name = column_name if arel.kind_of?(Arel::Nodes::Grouping)
+          arel
+        end
+
         private
 
-        def define_virtual_arel(name, arel)
+        def define_virtual_arel(name, arel) # :nodoc:
           self._virtual_arel = _virtual_arel.merge(name => arel)
         end
       end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -55,9 +55,17 @@ class Author < VirtualTotalTestBase
     nickname || name
   end
 
+  alias name_no_group nick_or_name
+
   # a (local) virtual_attribute without a uses, but with arel
   virtual_attribute :nick_or_name, :string, :arel => (lambda do |t|
     t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [t[:nickname], t[:name]]))
+  end)
+
+  # We did not support arel returning something other than Grouping.
+  # this is here to test what happens when we do
+  virtual_attribute :name_no_group, :string, :arel => (lambda do |t|
+    Arel::Nodes::NamedFunction.new('COALESCE', [t[:nickname], t[:name]])
   end)
 
   def first_book_name

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -803,6 +803,11 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
     it "supports virtual attributes" do
       Author.select(:id, :nick_or_name).first
     end
+
+    it "supports virtual attributes with non grouping return" do
+      author = Author.select(:id, :name_no_group).first
+      expect(author.has_attribute?(:name_no_group)).to be(true)
+    end
   end
 
   describe ".where" do


### PR DESCRIPTION
### Background

There has always been an non-enforced rule that the arel generated for a virtual_attribute needs to be wrapped in parenthesis. In Arel, this is called "grouping" aka `Arel::Nodes::Grouping`

### Before

If the Arel returned from `virtual_attribute :arel => lambda {}` is not a `Grouping`, the virtual attribute will be silently ignored.

### After

If the Arel returned from `virtual_attribute :arel => lambda {}` is not a `Grouping`, the node will be converted to a `Grouping`
