### PR TITLE
Cleanup for consistency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,27 +15,20 @@ jobs:
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: virtual_attributes
+        options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
         ports:
         - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 2s
-          --health-timeout 5s
-          --health-retries 5
       mysql:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: virtual_attributes
+        options: --health-cmd="mysqladmin ping -h 127.0.0.1 -P 3306 --silent" --health-interval 10s --health-timeout 5s --health-retries 3
         ports:
         - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1 -P 3306 --silent"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 3
     env:
-      # for the pg cli (psql, pg_isready) and possibly rails
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      # for the pg cli (psql, pg_isready) and rails
       PGHOST: localhost
       PGPORT: 5432
       PGUSER: postgres
@@ -53,21 +46,18 @@ jobs:
       - name: Run SQLite tests
         env:
           DB: sqlite3
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: bundle exec rake
-      - name: Run Postgres tests
+      - name: Run PostgreSQL tests
         env:
           DB: pg
           COLLATE_SYMBOLS: false
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: bundle exec rake
       - name: Run MySQL tests
         env:
           DB: mysql2
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: bundle exec rake
-      - if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '2.7' }}
-        name: Report code coverage
+      - name: Report code coverage
+        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '2.7' }}
         continue-on-error: true
         uses: paambaati/codeclimate-action@v3.0.0
         env:


### PR DESCRIPTION
Clean up the GHA workflow to be consistent with other repos
- Inline the options
- ports after options
- Move CC_TEST_REPORTER_ID to global env