### PR TITLE
Fix virtual attributes and IN clauses

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_arel.rb
+++ b/lib/active_record/virtual_attributes/virtual_arel.rb
@@ -12,7 +12,12 @@ module ActiveRecord
 
     # in essence, this is our Arel::Nodes::VirtualAttribute
     class Arel::Nodes::Grouping
-      attr_accessor :name
+      attr_accessor :name, :relation
+
+      # methods from Arel::Nodes::Attribute
+      def type_caster
+        relation.type_for_attribute(name)
+      end
     end
 
     module VirtualArel
@@ -86,6 +91,7 @@ module ActiveRecord
           arel = arel_lambda.call(table)
           arel = Arel::Nodes::Grouping.new(arel) unless arel.kind_of?(Arel::Nodes::Grouping)
           arel.name = column_name
+          arel.relation = table
           arel
         end
 

--- a/lib/active_record/virtual_attributes/virtual_arel.rb
+++ b/lib/active_record/virtual_attributes/virtual_arel.rb
@@ -18,6 +18,21 @@ module ActiveRecord
       def type_caster
         relation.type_for_attribute(name)
       end
+
+      # Create a node for lowering this attribute
+      def lower
+        relation.lower(self)
+      end
+
+      def type_cast_for_database(value)
+        relation.type_cast_for_database(name, value)
+      end
+
+      # rubocop:disable Rails/Delegate
+      def able_to_type_cast?
+        relation.able_to_type_cast?
+      end
+      # rubocop:enable Rails/Delegate
     end
 
     module VirtualArel

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -52,10 +52,13 @@ class Author < VirtualTotalTestBase
   alias v_total_named_books total_named_books
 
   def nick_or_name
-    nickname || name
+    has_attribute?("nick_or_name") ? self["nick_or_name"] : nickname || name
   end
 
-  alias name_no_group nick_or_name
+  # sorry. no creativity on this one (just copied nick_or_name)
+  def name_no_group
+    has_attribute?("name_no_group") ? self["name_no_group"] : nickname || name
+  end
 
   # a (local) virtual_attribute without a uses, but with arel
   virtual_attribute :nick_or_name, :string, :arel => (lambda do |t|
@@ -69,15 +72,15 @@ class Author < VirtualTotalTestBase
   end)
 
   def first_book_name
-    books.first.name
+    has_attribute?("first_book_name") ? self["first_book_name"] : books.first.name
   end
 
   def first_book_author_name
-    books.first.author_name
+    has_attribute?("first_book_author_name") ? self["first_book_author_name"] : books.first.author_name
   end
 
   def upper_first_book_author_name
-    first_book_author_name.upcase
+    has_attribute?("upper_first_book_author_name") ? self["upper_first_book_author_name"] : first_book_author_name.upcase
   end
 
   # basic attribute with uses that doesn't use a virtual attribute
@@ -127,11 +130,11 @@ class Book < VirtualTotalTestBase
   virtual_attribute :upper_author_name_def, :string, :uses => :upper_author_name
 
   def upper_author_name
-    author_name.upcase
+    has_attribute?("upper_author_name") ? self["upper_author_name"] : author_name.upcase
   end
 
   def upper_author_name_def
-    upper_author_name || "other"
+    has_attribute?("upper_author_name_def") ? self["upper_author_name_def"] : upper_author_name || "other"
   end
 
   def self.create_with_bookmarks(count)

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -779,23 +779,49 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   end
 
   describe ".select" do
+    before do
+      Author.delete_all
+    end
     it "supports virtual attributes" do
-      Author.select(:id, :nick_or_name).first
+      Author.create(:name => "abc")
+      expect(Author.select(:id, :nick_or_name).first.nick_or_name).to eq("abc")
     end
 
     it "supports virtual attributes with non grouping return" do
+      Author.create(:name => "abc")
       author = Author.select(:id, :name_no_group).first
       expect(author.has_attribute?(:name_no_group)).to be(true)
     end
   end
 
   describe ".where" do
-    it "supports virtual attributes hash syntax" do
-      Author.where(:nick_or_name => "abc").first
+    before do
+      Author.delete_all
+    end
+
+    it "supports virtual attributes hash syntax a" do
+      author = Author.create(:name => "name")
+      Author.create(:name => "other")
+
+      expect(Author.where(:nick_or_name => "name").first).to eq(author)
+      expect(Author.where(:nick_or_name => "name").count).to eq(1)
+    end
+
+    it "supports virtual attributes hash syntax b" do
+      author = Author.create(:nickname => "nick")
+      Author.create(:nickname => "other")
+
+      expect(Author.where(:nick_or_name => "nick").first).to eq(author)
+      expect(Author.where(:nick_or_name => "nick").count).to eq(1)
     end
 
     it "supports virtual attributes arel syntax" do
-      Author.where(Author.arel_table[:total_books].gt(5)).first
+      author = Author.create_with_books(6)
+      Author.create_with_books(2)
+
+      rslt = Author.where(Author.arel_table[:total_books].gt(5)).first
+      expect(rslt).to eq(author)
+      expect(Author.where(Author.arel_table[:total_books].gt(5)).count).to eq(1)
     end
   end
 

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -815,6 +815,12 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
       expect(Author.where(:nick_or_name => "nick").count).to eq(1)
     end
 
+    it "supports virtual attributes hash in syntax" do
+      author = Author.create(:name => "abc")
+      rslt = Author.where(:nick_or_name => %w[abc def]).first
+      expect(rslt).to eq(author)
+    end
+
     it "supports virtual attributes arel syntax" do
       author = Author.create_with_books(6)
       Author.create_with_books(2)


### PR DESCRIPTION
6.1 introduced `HomogeneousIn`, an optimization for the `In` clause.
This introduced changes to `Attribute` that required our attention.

An attribute now needs to have a `name`, and be able to type cast parameters for the
datatype.

This change gives the virtual attribute more information for type casting.

Put in a PR for rails to hopefully remove our requirement to monkey patch
that operator. https://github.com/rails/rails/pull/45642