### PR TITLE
Introduce Arel::Nodes::VirtualAttribute

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -261,7 +261,7 @@ module ActiveRecord
 
         yield arel if block_given?
 
-        ::Arel::Nodes::Grouping.new(arel)
+        arel
       end
 
       # determine table reference to use for a sub query

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -244,7 +244,7 @@ module ActiveRecord
         if select_values.any?
           cols = arel_columns(select_values).map do |col|
             # if it is a virtual attribute, then add aliases to those columns
-            if col.kind_of?(Arel::Nodes::Grouping) && col.name
+            if col.kind_of?(VirtualAttributes::VirtualAttribute)
               col.as(connection.quote_column_name(col.name))
             else
               col

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -109,7 +109,7 @@ module VirtualAttributes
           query.where(join.right.expr)
 
           # add coalesce to ensure correct value comes out
-          t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [t.grouping(query), Arel.sql("0")]))
+          Arel::Nodes::NamedFunction.new('COALESCE', [t.grouping(query), Arel.sql("0")])
         end
       end
     end


### PR DESCRIPTION
## Overview

Virtual attributes need an attribute name. The node representing the attribute needs to return a name and type.

In order to work with `ToSql`, this needs to be in the `Arel::Nodes::` namespace.

## Before

- `Arel::Nodes::Grouping` was monkeypatched to return `name` and `relation`.

Reminder: This node represents the parenthesized grouping of sql.

## After

- Remove monkey patch from `Arel::Nodes::Grouping`
- Introduce `Arel::Nodes::VirtualAttribute` that is basically a grouping
- `ToSql` treats this node as a `Grouping` (since that is the parent class)

