### PR TITLE
add ruby 3.1 to test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         ruby-version:
         - '2.7'
+        - '3.1'
     services:
       postgres:
         image: postgres:13
@@ -62,7 +63,7 @@ jobs:
           DB: mysql2
         run: bundle exec rake
       - name: Report code coverage
-        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '2.7' }}
+        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}
         continue-on-error: true
         uses: paambaati/codeclimate-action@v3.0.0
         env:


### PR DESCRIPTION
I noticed that we were still testing 2.7
Adding 3.1 support

Nothing happened to make me think this will break, but wanted to put putting this in place.

remember: We are linking our version to active record version numbers, so this branch (master is rails 6.1.x specific