### PR TITLE
Use database_cleaner to clear out tables

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "activerecord", "~> 6.1.0"
 
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "database_cleaner-active_record", "~> 2.1"
   spec.add_development_dependency "db-query-matchers"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/bin/setup
+++ b/bin/setup
@@ -5,4 +5,7 @@ set -vx
 
 bundle install
 
+psql -c 'create database virtual_attributes;' || echo 'db exists'
+mysql -u root -e 'CREATE SCHEMA IF NOT EXISTS 'virtual_attributes';'
+
 # Do any other automated setup that you need to do here

--- a/spec/preload_values_spec.rb
+++ b/spec/preload_values_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe "preloads_values" do
   before do
-    Author.destroy_all
-    Book.destroy_all
     Author.create_with_books(3).books.first.create_bookmarks(2)
   end
 

--- a/spec/preload_values_spec.rb
+++ b/spec/preload_values_spec.rb
@@ -6,39 +6,38 @@ RSpec.describe "preloads_values" do
   let(:author_name) { "foo" }
   let(:book_name) { "bar" }
 
-  it "detects preloaded values" do
+  it "detects values preloaded with a value" do
     expect(Book.select(:author_name)).to preload_values(:author_name, [author_name, author_name])
   end
 
-  it "detects preloaded values converts to array" do
+  it "detects values preloaded (auto converts value to an array)" do
     expect(Book.select(:author_name)).to preload_values(:author_name, author_name)
   end
 
-  it "detects not preloaded" do
+  it "detects values preloading failure" do
     expect do
       expect(Book).to preload_values(:author_name, author_name)
     end.to raise_error(RSpec::Expectations::ExpectationNotMetError, "Expected to preload author_name but executed 2 queries instead")
   end
 
-  it "detects incorrect values" do
+  it "detects values matching failure" do
     expect do
       expect(Book.select(:author_name)).to preload_values(:author_name, "bogus")
-    end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected:/)
   end
 
-  it "detects not preloading values" do
+  it "detects values not preloaded" do
     expect(Book).not_to preload_values(:author_name, author_name)
   end
 
-  # NOTE: was unsure if incorrect values met or failed the expectation
-  # went with the core of the expectation is preloading. but matching values trumps all
-  it "detects not preloading values (bad value)" do
+  # even though we said not to preload, still expecting values to match
+  it "detects values not preloaded but matching failures" do
     expect do
       expect(Book).not_to preload_values(:author_name, "bogus")
-    end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected:/)
   end
 
-  it "detects not preloading values failure" do
+  it "detects values not preloaded failure (expecting not preloaded but they were)" do
     expect do
       expect(Book.select(:author_name)).not_to preload_values(:author_name, author_name)
     end.to raise_error(RSpec::Expectations::ExpectationNotMetError, "Unexpectedly preloaded author_name")

--- a/spec/preload_values_spec.rb
+++ b/spec/preload_values_spec.rb
@@ -1,13 +1,13 @@
 RSpec.describe "preloads_values" do
   before do
-    Author.create_with_books(3).books.first.create_bookmarks(2)
+    Author.create_with_books(2)
   end
 
   let(:author_name) { "foo" }
   let(:book_name) { "bar" }
 
   it "detects preloaded values" do
-    expect(Book.select(:author_name)).to preload_values(:author_name, [author_name, author_name, author_name])
+    expect(Book.select(:author_name)).to preload_values(:author_name, [author_name, author_name])
   end
 
   it "detects preloaded values converts to array" do
@@ -17,7 +17,7 @@ RSpec.describe "preloads_values" do
   it "detects not preloaded" do
     expect do
       expect(Book).to preload_values(:author_name, author_name)
-    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, "Expected to preload author_name but executed 3 queries instead")
+    end.to raise_error(RSpec::Expectations::ExpectationNotMetError, "Expected to preload author_name but executed 2 queries instead")
   end
 
   it "detects incorrect values" do

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -779,9 +779,6 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   end
 
   describe ".select" do
-    before do
-      Author.delete_all
-    end
     it "supports virtual attributes" do
       Author.create(:name => "abc")
       expect(Author.select(:id, :nick_or_name).first.nick_or_name).to eq("abc")
@@ -795,10 +792,6 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   end
 
   describe ".where" do
-    before do
-      Author.delete_all
-    end
-
     it "supports virtual attributes hash syntax a" do
       author = Author.create(:name => "name")
       Author.create(:name => "other")
@@ -832,12 +825,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   end
 
   describe ".order" do
-    before do
-      Author.delete_all
-      authors
-    end
-
-    let(:authors) do
+    let!(:authors) do
       [
         Author.create(:name => "aaa"),
         Author.create(:nickname => "bbb"),

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -245,8 +245,6 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     end
 
     it "respects type" do
-      Author.delete_all
-      Book.delete_all
       author = Author.create(:name => "no one of consequence")
       book = author.books.create(:name => "nothing of consequence", :id => author.id)
       book.photos.create(:description => 'bad')
@@ -256,8 +254,6 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     end
 
     it "handles polymorphic in" do
-      Author.delete_all
-      Book.delete_all
       author = Author.create(:name => "no one of consequence")
       author.books.create(:name => "nothing of consequence", :id => author.id)
       author.photos.create(:description => 'good')
@@ -267,8 +263,6 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     end
 
     it "handles polymorphic or" do
-      Author.delete_all
-      Book.delete_all
       author = Author.create(:name => "no one of consequence")
       author.books.create(:name => "nothing of consequence", :id => author.id)
       author.photos.create(:description => 'good')

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
   before do
-    Author.destroy_all
-    Book.destroy_all
     Author.create_with_books(3).books.first.create_bookmarks(2)
   end
 

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -1,10 +1,4 @@
 RSpec.describe VirtualAttributes::VirtualTotal do
-  before do
-    Author.delete_all
-    Book.delete_all
-    Bookmark.delete_all
-  end
-
   describe ".select" do
     it "supports virtual_totals" do
       Author.select(:id, :total_books).first


### PR DESCRIPTION
We would like to clean up all records created in each test.
This was not properly working before so we had to manually delete records ourselves.

Rails ActiveRecord does provide `transactional_features` for tests, but it is not
so simple to implement. This functionality is provided by `rspec-rails`, but not
in standard `rspec` (which we are using).

Using DatabaseCleaner gem to clean up after each test.
The `transaction` strategy should work for us since we only use a single database
and a single connection.