### PR TITLE
Handle 'uses' delegating to another 'uses' that has a deep hash

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -69,7 +69,9 @@ module ActiveRecord
           when String, Symbol
             {value => {}}
           when Array
-            value.flatten.each_with_object({}) { |k, h| h[k] = {} }
+            value.flatten.each_with_object({}) do |k, h|
+              merge_includes(h, k)
+            end
           when nil
             {}
           else

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -77,15 +77,14 @@ module ActiveRecord
           end
         end
 
-        # @param [Hash] hash1
-        # @param [Hash] hash2
+        # @param [Hash] hash1 (incoming hash is modified and returned)
+        # @param [Hash|Symbol|nil] hash2 (this hash will not be modified)
         def merge_includes(hash1, hash2)
           return hash1 if hash2.blank?
 
-          hash1 = include_to_hash(hash1)
-          hash2 = include_to_hash(hash2)
-          hash1.deep_merge!(hash2) do |_k, v1, v2|
-            merge_includes(v1, v2)
+          hash1.deep_merge!(include_to_hash(hash2)) do |_k, v1, v2|
+            # this block is conflict resolution when a key has 2 values
+            merge_includes(include_to_hash(v1), v2)
           end
         end
       end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -84,6 +84,13 @@ module ActiveRecord
         def merge_includes(hash1, hash2)
           return hash1 if hash2.blank?
 
+          # very common case.
+          # optimization to skip deep_merge and hash creation
+          if hash2.kind_of?(Symbol)
+            hash1[hash2] ||= {}
+            return hash1
+          end
+
           hash1.deep_merge!(include_to_hash(hash2)) do |_k, v1, v2|
             # this block is conflict resolution when a key has 2 values
             merge_includes(include_to_hash(v1), v2)

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -126,6 +126,8 @@ class Book < VirtualTotalTestBase
   # this tests delegate
   # this also tests an attribute :uses clause with a single symbol
   virtual_delegate :name, :to => :author, :prefix => true, :type => :string
+  # this tests delegates to named child attribute
+  virtual_delegate :author_name2, :to => "author.name", :type => :string
   # delegate to a polymorphic
   virtual_delegate :description, :to => :current_photo, :prefix => true, :type => :string, :allow_nil => true
 

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -87,6 +87,10 @@ class Author < VirtualTotalTestBase
     has_attribute?("upper_first_book_author_name") ? self["upper_first_book_author_name"] : first_book_author_name.upcase
   end
 
+  def famous_co_authors
+    book_with_most_bookmarks&.co_authors || []
+  end
+
   # basic attribute with uses that doesn't use a virtual attribute
   def book_with_most_bookmarks
     books.max_by { |book| book.bookmarks.size }
@@ -99,6 +103,11 @@ class Author < VirtualTotalTestBase
   virtual_attribute :first_book_author_name, :string, :uses => {:books => :author_name}
   # uses another virtual attribute that uses a relation
   virtual_attribute :upper_first_book_author_name, :string, :uses => :first_book_author_name
+  # :uses points to a virtual_attribute that has a :uses with a hash
+  # NOTE: Please do not change the :uses format here.
+  #   This intentionally tests :uses with an array: [:bwmb, {:books => co_a}]
+  #   vs a more condensed format: {:bwmb => {}, :books => co_a}
+  virtual_has_many :famous_co_authors, :uses => [:book_with_most_bookmarks, {:books => :co_authors}]
 
   def self.create_with_books(count)
     create!(:name => "foo").tap { |author| author.create_books(count) }

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -374,6 +374,15 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       bookmarked_book = Author.first.books.first
       expect(Author.includes([{:book_with_most_bookmarks => {}}, :books]).references(:book_with_most_bookmarks, :books)).to preload_values(:book_with_most_bookmarks, bookmarked_book)
     end
+
+    it "preloads virtual_reflection(:uses => :books => :bookmarks, :books) (nothing virtual)" do
+      other_author_name = "Drew"
+      other_author = Author.create(:name => other_author_name)
+      Author.first.books.first.co_authors << other_author
+
+      # first author has [co-author], second author (aka other_author) has none
+      expect { Author.includes(:famous_co_authors).references(:famous_co_authors) }.to preload_values(:famous_co_authors, [[other_author], []])
+    end
   end
 
   context "preloads virtual_reflection with preloader" do
@@ -523,6 +532,10 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.replace_virtual_fields(:nick_or_name)).to eq(nil)
       expect(Author.replace_virtual_fields([:nick_or_name])).to eq([])
       expect(Author.replace_virtual_fields(:nick_or_name => {})).to eq({})
+    end
+
+    it "handles deep includes with va indirect uses(:uses => :books => :bookmarks)" do
+      expect(Author.replace_virtual_fields(:famous_co_authors => {})).to eq({:books => {:bookmarks => {}, :co_authors => {}}})
     end
   end
 


### PR DESCRIPTION
## Issue

The use case that triggered this had more layers of indirection.
But the jist is when we map a `:uses` with an array, and one of the entries has a complex `:uses`,
it will end up with a nested hash.

```
virtual_has_many :field1, :uses => {:a => :b}
virtual_has_many :field2, :uses => :c
virtual_has_many :field3, :uses => [:field1, :field2]
```

## Before

```
references([:field3])
=>
references([:field1, :field2])
=>
references([{:a => :b}, :c]
```

And when we map that into a hash we end up with
```
{{:a => :b} => {}, :c => {}}
```
where `{:a => :b}` is a key pointing to an empty hash (i.e.: `{}`)

### So we blow up

```
Issue with `Vm#used_storage`:

ERROR -- evm: [NoMethodError]: undefined method `to_sym' for {:hardware=>:disks}:Hash
Did you mean?  to_s
               to_set
ERROR -- evm: lib/active_record/virtual_attributes/virtual_reflections.rb:36:in `virtual_reflection?`
lib/active_record/virtual_attributes/virtual_fields.rb:30:in `virtual_field?`
lib/active_record/virtual_attributes/virtual_fields.rb:50:in `block in replace_virtual_field_hash`
lib/active_record/virtual_attributes/virtual_fields.rb:49:in `each`
```


## After

We don't assume that all entries in the input array are a string/symbol:
so we end up with simple keys in the destination hash:

```
{:a => :b, :c => {}}
```

Fixes https://github.com/ManageIQ/manageiq/issues/22526
