### PR TITLE
support bind variables in virtual delegate reflections

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -261,7 +261,9 @@ module ActiveRecord
         yield arel if block_given?
 
         # convert arel to sql to populate with bind variables
-        ::Arel::Nodes::Grouping.new(Arel.sql(arel.to_sql))
+        conn = to_ref.klass.connection
+        sql = conn.unprepared_statement { conn.to_sql(arel) }
+        ::Arel::Nodes::Grouping.new(Arel.sql(sql))
       end
 
       # determine table reference to use for a sub query

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -13,6 +13,7 @@ class Author < VirtualTotalTestBase
   has_many :bookmarks,                         :class_name => "Bookmark", :through => :books
   has_many :photos, :as => :imageable, :class_name => "Photo"
   has_one :current_photo, -> { all.merge(Photo.order(:id => :desc)) }, :as => :imageable, :class_name => "Photo"
+  has_one :fancy_photo, -> { where(:purpose => "fancy") }, :as => :imageable, :class_name => "Photo"
 
   virtual_total :total_books, :books
   virtual_total :total_books_published, :published_books
@@ -32,6 +33,7 @@ class Author < VirtualTotalTestBase
   virtual_maximum :maximum_recently_published_books_rating, :recently_published_books, :rating
   virtual_sum :sum_recently_published_books_rating, :recently_published_books, :rating
   virtual_delegate :description, :to => :current_photo, :prefix => true, :type => :string
+  virtual_delegate :description, :to => :fancy_photo, :prefix => true, :type => :string
 
   # This is here to provide a virtual_total of a virtual_has_many that depends upon an array of associations.
   # NOTE: this is tailored to the use case and is not an optimal solution

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(:version => 0) do
 
   create_table "photos", :force => true do |t|
     t.references "imageable", :polymorphic => true
+    t.string "purpose"
     t.string "description"
   end
 end

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -244,6 +244,14 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       expect(author.current_photo_description).to eq("good")
     end
 
+    it "supports bind variables in association" do
+      author = Author.create(:name => "no one of consequence")
+      author.photos.create(:description => 'good', :purpose => "fancy")
+
+      author = Author.select(:id, :fancy_photo_description).find(author.id)
+      expect(author).to preload_values(:fancy_photo_description, "good")
+    end
+
     it "respects type" do
       author = Author.create(:name => "no one of consequence")
       book = author.books.create(:name => "nothing of consequence", :id => author.id)


### PR DESCRIPTION
We were not properly escaping the arel in the association de-reference.

This use case is very particular and will only happen with hard coded strings in associations.

13016ba214dbfd98 rewrote to_sql to wrap in unprepared_statement in one spot but not in this spot. So I guess this continued that effort.

a53d9597d4550345 stated there was a problem but had no reproducer This added specs, but they don't look like they would be able to detect the mentioned issue. So I guess this continued that effort as well.