### PR TITLE
Support virtual_totals for habtm

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -114,7 +114,7 @@ module VirtualAttributes
       end
 
       def virtual_aggregate_arel(reflection, method_name, column)
-        return unless reflection && reflection.macro == :has_many
+        return unless reflection && [:has_many, :has_and_belongs_to_many].include?(reflection.macro)
 
         # need db access for the reflection join_keys, so delaying all this key lookup until call time
         lambda do |t|

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -19,9 +19,11 @@ class Author < VirtualTotalTestBase
   virtual_total :total_books_in_progress, :wip_books
   # same as total_books, but going through a relation with order
   virtual_total :total_ordered_books, :ordered_books
-  # virtual total using through
+  # virtual total using has_many :through
   virtual_total :total_bookmarks, :bookmarks
   alias v_total_bookmarks total_bookmarks
+  # virtual total using has_and_belongs_to_many
+  virtual_total :total_co_books, :co_books
 
   has_many :recently_published_books, -> { published.order(:created_on => :desc) },
            :class_name => "Book", :foreign_key => "author_id"

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe VirtualAttributes::VirtualTotal do
     it "supports virtual_totals" do
       Author.select(:id, :total_books).first
     end
+
+    it "supports habtm" do
+      author = Author.create_with_books(2)
+      co_a = Author.create
+      author.books.each { |book| co_a.co_books << book }
+
+      expect(Author.select(:id, :total_co_books).find(co_a.id)).to preload_values(:total_co_books, 2)
+    end
   end
 
   describe ".where" do


### PR DESCRIPTION
We rewrote virtual_totals to leverage the sql generated by rails: https://github.com/ManageIQ/activerecord-virtual_attributes/pull/52

This was to support `has_many :through`, but it also supports habtm