### PR TITLE
Arel with binds

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -261,7 +261,9 @@ module ActiveRecord
         yield arel if block_given?
 
         # convert arel to sql to populate with bind variables
-        ::Arel::Nodes::Grouping.new(Arel.sql(arel.to_sql))
+        conn = to_ref.klass.connection
+        sql = conn.unprepared_statement { conn.to_sql(arel) }
+        ::Arel::Nodes::Grouping.new(Arel.sql(sql))
       end
 
       # determine table reference to use for a sub query

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -260,10 +260,7 @@ module ActiveRecord
 
         yield arel if block_given?
 
-        # convert arel to sql to populate with bind variables
-        conn = to_ref.klass.connection
-        sql = conn.unprepared_statement { conn.to_sql(arel) }
-        ::Arel::Nodes::Grouping.new(Arel.sql(sql))
+        ::Arel::Nodes::Grouping.new(arel)
       end
 
       # determine table reference to use for a sub query

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -137,14 +137,8 @@ module VirtualAttributes
           # query: SELECT COUNT(*) FROM foreign_table JOIN ... [WHERE main_table.id = foreign_table.id]
           query.where(join.right.expr)
 
-          # convert bind variables from ? to actual values. otherwise, sql is incomplete
-          conn = connection
-          sql = conn.unprepared_statement { conn.to_sql(query) }
-
-          # add () around query
-          query = t.grouping(Arel::Nodes::SqlLiteral.new(sql))
           # add coalesce to ensure correct value comes out
-          t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [query, Arel::Nodes::SqlLiteral.new("0")]))
+          t.grouping(Arel::Nodes::NamedFunction.new('COALESCE', [t.grouping(query), Arel::Nodes::SqlLiteral.new("0")]))
         end
       end
     end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -13,6 +13,7 @@ class Author < VirtualTotalTestBase
   has_many :bookmarks,                         :class_name => "Bookmark", :through => :books
   has_many :photos, :as => :imageable, :class_name => "Photo"
   has_one :current_photo, -> { all.merge(Photo.order(:id => :desc)) }, :as => :imageable, :class_name => "Photo"
+  has_one :fancy_photo, -> { where(:purpose => "fancy") }, :as => :imageable, :class_name => "Photo"
 
   virtual_total :total_books, :books
   virtual_total :total_books_published, :published_books
@@ -32,6 +33,7 @@ class Author < VirtualTotalTestBase
   virtual_maximum :maximum_recently_published_books_rating, :recently_published_books, :rating
   virtual_sum :sum_recently_published_books_rating, :recently_published_books, :rating
   virtual_delegate :description, :to => :current_photo, :prefix => true, :type => :string
+  virtual_delegate :description, :to => :fancy_photo, :prefix => true, :type => :string
 
   # This is here to provide a virtual_total of a virtual_has_many that depends upon an array of associations.
   # NOTE: this is tailored to the use case and is not an optimal solution

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(:version => 0) do
 
   create_table "photos", :force => true do |t|
     t.references "imageable", :polymorphic => true
+    t.string "purpose"
     t.string "description"
   end
 end

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -244,6 +244,14 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       expect(author.current_photo_description).to eq("good")
     end
 
+    it "supports bind variables in association" do
+      author = Author.create(:name => "no one of consequence")
+      author.photos.create(:description => 'good', :purpose => "fancy")
+
+      author = Author.select(:id, :fancy_photo_description).find(author.id)
+      expect(author).to preload_values(:fancy_photo_description, "good")
+    end
+
     it "respects type" do
       author = Author.create(:name => "no one of consequence")
       book = author.books.create(:name => "nothing of consequence", :id => author.id)


### PR DESCRIPTION
Depends:

- [ ] #122 (first commit -- this PR undoes it)

It was necessary for years to convert the virtual attributes over to sql to remove
bind variables.

Since we have successfully added tests around habtm, `has_many :through`, and
relations with string types, it feels our coverage is good enough to trust them
around bind variables.

This removes some string processing / objects created, but more importantly, gets us away from calling `Arel.sql(arel.to_sql)` and just passing `arel`.

WIP: would like to merge a few of these other PRs and run miq cross test suite against this.
currently, I'm leaning towards merging this