### PR TITLE
[WIP] Add support for testing future Rails versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ jobs:
         ruby-version:
         - '2.7'
         - '3.1'
+        rails-version:
+        - '6.1'
+        - '7.0'
     services:
       postgres:
         image: postgres:13
@@ -32,6 +35,7 @@ jobs:
         ports:
         - 3306:3306
     env:
+      RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       # for the pg cli (psql, pg_isready) and rails
       PGHOST: localhost
@@ -50,20 +54,23 @@ jobs:
           bundler-cache: true
         timeout-minutes: 30
       - name: Run SQLite tests
+        continue-on-error: ${{ matrix.rails-version != '6.1' }}
         env:
           DB: sqlite3
         run: bundle exec rake
       - name: Run PostgreSQL tests
+        continue-on-error: ${{ matrix.rails-version != '6.1' }}
         env:
           DB: postgresql
           COLLATE_SYMBOLS: false
         run: bundle exec rake
       - name: Run MySQL tests
+        continue-on-error: ${{ matrix.rails-version != '6.1' }}
         env:
           DB: mysql2
         run: bundle exec rake
       - name: Report code coverage
-        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}
+        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' && matrix.rails-version == '6.1' }}
         continue-on-error: true
         uses: paambaati/codeclimate-action@v3.0.0
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.4"
 gem "mysql2"
 gem "pg"
 gem "sqlite3"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ To test with different database adapters, set the DB environment variable:
     DB=mysql bundle exec rake
     DB=sqlite3 bundle exec rake
 
+To test with different versions of Rails, set the RAILS_VERSION environment variable:
+
+    RAILS_VERSION=6.1 bundle exec rake
+    RAILS_VERSION=7.0 bundle exec rake
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/ManageIQ/activerecord-virtual_attributes .

--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 6.1.0"
+  spec.add_runtime_dependency "activerecord", "~> #{ENV.fetch("RAILS_VERSION", "6.1")}.0"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "database_cleaner-active_record", "~> 2.1"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require "active_record/virtual_attributes/rspec"
 require "database_cleaner/active_record"
 require "db-query-matchers"
 
+puts "\e[93mUsing ActiveRecord #{ActiveRecord.version}\e[0m"
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
@kbrock Please review.

I was thinking that we should run specs for future versions but allow them to fail. This allows us to fix future Rails things on master in a forward compatible way, if possible, hopefully making upgrades simpler.

Additionally, this allows easier switching locally by just passing RAILS_VERSION. Default for RAILS_VERSION if not passed is the expected release version.
