### PR TITLE
Cleanup setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         run: bundle exec rake
       - name: Run PostgreSQL tests
         env:
-          DB: pg
+          DB: postgresql
           COLLATE_SYMBOLS: false
         run: bundle exec rake
       - name: Run MySQL tests

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # VirtualAttributes
 
 [![CI](https://github.com/ManageIQ/activerecord-virtual_attributes/actions/workflows/ci.yaml/badge.svg)](https://github.com/ManageIQ/activerecord-virtual_attributes/actions/workflows/ci.yaml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/e1a0c26941c00f4edb55/maintainability)](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/e1a0c26941c00f4edb55/test_coverage)](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes/test_coverage)
+[![Maintainability](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes.svg)](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes/maintainability)
+[![Test Coverage](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes/coverage.svg)](https://codeclimate.com/github/ManageIQ/activerecord-virtual_attributes/test_coverage)
 
 VirtualAttributes allows you to define a ruby method that acts like an attribute or relation.
 
@@ -40,14 +40,15 @@ TODO: Write usage instructions here
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bundle exec rake` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+To test with different database adapters, set the DB environment variable:
 
-To test with different versions of ruby, use `wwtd` gem or
-
-DB=pg BUNDLE_GEMFILE=gemfiles/gemfile_${version-52}.gemfile bundle exec rake
+    DB=postgresql bundle exec rake
+    DB=mysql bundle exec rake
+    DB=sqlite3 bundle exec rake
 
 ## Contributing
 
@@ -56,4 +57,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/Manage
 ## License
 
 This project is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
-

--- a/bin/setup
+++ b/bin/setup
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 IFS=$'\n\t'
-set -vx
+set -e
 
 bundle install
+echo
 
-psql -c 'create database virtual_attributes;' || echo 'db exists'
+echo "Setting up the postgres database for specs..."
+echo "SELECT 'CREATE DATABASE virtual_attributes' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'virtual_attributes')\gexec" | psql -U postgres
+
+echo "Setting up the mysql database for specs..."
 mysql -u root -e 'CREATE SCHEMA IF NOT EXISTS 'virtual_attributes';'
-
-# Do any other automated setup that you need to do here

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -3,7 +3,7 @@ sqlite3:
   database: ":memory:"
   encoding: utf8
 
-pg:
+postgresql:
   adapter: postgresql
   database: virtual_attributes
   encoding: utf8

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,10 +26,13 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
+    puts "\e[93mUsing database adapter #{Database.adapter}\e[0m"
+    Database.new.setup.migrate
+
     # truncate at startup
     DatabaseCleaner.clean_with :truncation
     # transaction between examples (mysql requires truncation)
-    DatabaseCleaner.strategy = ENV["DB"].to_s.include?("mysql") ? :truncation : :transaction
+    DatabaseCleaner.strategy = Database.adapter.include?("mysql") ? :truncation : :transaction
   end
 
   config.around(:each) do |example|


### PR DESCRIPTION
- Change bin/setup to do a "create if exists" for postgres
- Change bin/setup to not be overly verbose
- Change the DB env var to match the adapter name
  - Isolate DB env var logic to the Database.adapter method
  - Keep short-form adapter names for convenience

@kbrock Please review.  Just some small refactorings and cleanups that I pulled out of #125 .