### PR TITLE
[WIP] Supports ruby code for default value

### DIFF
--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -4,6 +4,7 @@ require "active_record"
 require "active_record/virtual_attributes/virtual_includes"
 require "active_record/virtual_attributes/virtual_arel"
 require "active_record/virtual_attributes/virtual_delegates"
+require "active_record/virtual_attributes/ruby"
 
 module ActiveRecord
   module VirtualAttributes
@@ -11,6 +12,10 @@ module ActiveRecord
     include ActiveRecord::VirtualAttributes::VirtualIncludes
     include ActiveRecord::VirtualAttributes::VirtualArel
     include ActiveRecord::VirtualAttributes::VirtualDelegates
+
+    def self.ruby(value)
+      Ruby.new(value)
+    end
 
     module Type
       # TODO: do we actually need symbol types?

--- a/lib/active_record/virtual_attributes/ruby.rb
+++ b/lib/active_record/virtual_attributes/ruby.rb
@@ -1,0 +1,13 @@
+module ActiveRecord
+  module VirtualAttributes
+    class Ruby
+      def initialize(value)
+        @value = value
+      end
+
+      def inspect
+        @value
+      end
+    end
+  end
+end

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -633,6 +633,18 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
         tc = TestClass.new
         expect(tc.parent_col1).to eq("def")
       end
+
+      it "defaults for to nil child (complex string)" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => "'def'+1"
+        tc = TestClass.new
+        expect(tc.parent_col1).to eq("'def'+1")
+      end
+
+      it "defaults for to nil child (ruby)" do
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => ActiveRecord::VirtualAttributes.ruby('(1+2).to_s')
+        tc = TestClass.new
+        expect(tc.parent_col1).to eq("3")
+      end
     end
 
     describe "#sum" do


### PR DESCRIPTION
Supports ruby code for default value

Problem
=======

```ruby
virtual_delegate :name, :to => other, :default => _("Unknown")
```

The above code runs the localization routine at class load time.
We want a way to run it at runtime.

```ruby
virtual_delegate :name, :to => other, :default => '_("Unknown")'
```

Returns the actual string referenced.

We do not support lambdas:

```ruby
virtual_delegate :name, :to => other, :default => -> { _("Unknown") }
```

We need a way to lazy evaluate the code

Solution
===

This takes inspiration from `Arel.sql("value")`.
You are explicitly telling people that you are using this sql without escaping.

In our case, we are using this ruby code for our default value (and not an escaped string)

```ruby
virtual_delegate :name, :to => other, :default => ActiveRecord::VirtualAttributes.code('_("Unknown")')
```
