### PR TITLE
Symbol includes

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -43,7 +43,7 @@ module ActiveRecord
             method_prefix = virtual_delegate_name_prefix(options[:prefix], to)
             method_name = "#{method_prefix}#{method}"
             if to.include?(".") # to => "target.method"
-              to, method = to.split(".")
+              to, method = to.split(".").map(&:to_sym)
               options[:to] = to
             end
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -35,7 +35,7 @@ module ActiveRecord
 
           case associations
           when String, Symbol
-            virtual_field?(associations) ? replace_virtual_fields(virtual_includes(associations)) : associations
+            virtual_field?(associations) ? replace_virtual_fields(virtual_includes(associations)) : associations.to_sym
           when Array
             associations.collect { |association| replace_virtual_fields(association) }.compact
           when Hash
@@ -67,7 +67,7 @@ module ActiveRecord
         def include_to_hash(value)
           case value
           when String, Symbol
-            {value => {}}
+            {value.to_sym => {}}
           when Array
             value.flatten.each_with_object({}) do |k, h|
               merge_includes(h, k)

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -525,7 +525,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "handles hash form of delegates" do
-      expect(Book.replace_virtual_fields([{:author_name => {}}, {:author_name2 => {}}])).to eq([{:author => {}}, {"author" => {}}])
+      expect(Book.replace_virtual_fields([{:author_name => {}}, {:author_name2 => {}}])).to eq([{:author => {}}, {:author => {}}])
     end
 
     it "handles non-'includes' virtual_attributes" do

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -490,7 +490,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "merges hash, string" do
       first  = {:key => {:more => {}}}
       second = "key"
-      result = {:key => {:more => {}}, "key" => {}}
+      result = {:key => {:more => {}}}
       expect(Author.merge_includes(first, second)).to eq(result)
     end
 
@@ -519,7 +519,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     # TODO: produce {:books => :bookmarks} without the extra :books
     it "handles deep includes(:uses => :books => :bookmarks)" do
       expect(Author.replace_virtual_fields([:book_with_most_bookmarks, :books])).to eq([{:books => :bookmarks}, :books])
-      expect(Author.replace_virtual_fields(["book_with_most_bookmarks", "books"])).to eq([{:books => :bookmarks}, "books"])
+      expect(Author.replace_virtual_fields(["book_with_most_bookmarks", "books"])).to eq([{:books => :bookmarks}, :books])
       expect(Author.replace_virtual_fields([{:book_with_most_bookmarks => {}}, :books])).to eq([{:books => :bookmarks}, :books])
       expect(Author.replace_virtual_fields([{:book_with_most_bookmarks => {}}, {:books => {}}])).to eq([{:books => :bookmarks}, {:books => {}}])
     end


### PR DESCRIPTION
Clean up the symbol usage in the includes.

This contains 2 commits:

1. `virtual_delegates` now defines a symbolic `:uses` clause and generates a symbolic `includes` value for delegates that use the dot form(i.e.: `:to => "association.method"`)
2. `virtual_attribute :name, :uses => "table"` generates a symbolic `includes` (e.g.: `:table`)

Of note, this is not totally necessary.

- `ActiveRecord` seems to be ok with strings and symbols.
- `ActiveRecord` is also ok with duplicates (e.g.: `[:table, :table, "table"]`)

We currently still generate hashes and keys (e.g.: `[:table, {:table => :table2}]`). While I wish it were more clean, `ActiveRecord` is perfectly ok with this, too.

