### PR TITLE
Fix issue where sqlite3 2.x doesn't want to load with activerecord 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 6.1.4"
+gem "activerecord", "~> 6.1.7"
 gem "mysql2"
 gem "pg"
-gem "sqlite3"
+gem "sqlite3", "< 2"
 
 gemspec

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   context "TestClass", :with_test_class do
     it "should not have any virtual columns" do


### PR DESCRIPTION
Additionally, once sqlite3 is downgraded, the latest json 2.7.2 causes issues where OpenStruct is not defined, which worked with json 2.7.1. Only the specs use OpenStruct, so we should explicitly require it.

@kbrock Please review.  This should get master back to green.