### PR TITLE
replace_virtual_field condenses returning includes

### DIFF
--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -127,10 +127,10 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
         it ".replace_virtual_fields" do
           expect(TestClass.replace_virtual_fields(:vcol1)).to be_nil
           expect(TestClass.replace_virtual_fields(:ref1)).to eq(:ref1)
-          expect(TestClass.replace_virtual_fields([:vcol1])).to eq([])
-          expect(TestClass.replace_virtual_fields([:vcol1, :ref1])).to eq([:ref1])
-          expect(TestClass.replace_virtual_fields(:vcol1 => {})).to eq({})
-          expect(TestClass.replace_virtual_fields(:vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
+          expect(TestClass.replace_virtual_fields([:vcol1].freeze)).to be_nil
+          expect(TestClass.replace_virtual_fields([:vcol1, :ref1].freeze)).to eq(:ref1)
+          expect(TestClass.replace_virtual_fields({:vcol1 => {}}.freeze)).to be_nil
+          expect(TestClass.replace_virtual_fields({:vcol1 => {}, :ref1 => {}}.freeze)).to eq(:ref1)
         end
       end
     end
@@ -158,15 +158,15 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
         end
 
         it ".replace_virtual_fields" do
-          expect(test_sub_class.replace_virtual_fields(:vcol1)).to             be_nil
-          expect(test_sub_class.replace_virtual_fields(:vcolsub1)).to          be_nil
+          expect(test_sub_class.replace_virtual_fields(:vcol1)).to be_nil
+          expect(test_sub_class.replace_virtual_fields(:vcolsub1)).to be_nil
           expect(test_sub_class.replace_virtual_fields(:ref1)).to eq(:ref1)
-          expect(test_sub_class.replace_virtual_fields([:vcol1])).to eq([])
-          expect(test_sub_class.replace_virtual_fields([:vcolsub1])).to eq([])
-          expect(test_sub_class.replace_virtual_fields([:vcolsub1, :vcol1, :ref1])).to eq([:ref1])
-          expect(test_sub_class.replace_virtual_fields(:vcol1    => {})).to eq({})
-          expect(test_sub_class.replace_virtual_fields(:vcolsub1 => {})).to eq({})
-          expect(test_sub_class.replace_virtual_fields(:vcolsub1 => {}, :vcol1 => {}, :ref1 => {})).to eq(:ref1 => {})
+          expect(test_sub_class.replace_virtual_fields([:vcol1].freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields([:vcolsub1].freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields([:vcolsub1, :vcol1, :ref1].freeze)).to eq(:ref1)
+          expect(test_sub_class.replace_virtual_fields({:vcol1    => {}}.freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields({:vcolsub1 => {}}.freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields({:vcolsub1 => {}, :vcol1 => {}, :ref1 => {}}.freeze)).to eq(:ref1)
         end
       end
     end
@@ -341,10 +341,10 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
         it ".replace_virtual_fields" do
           expect(TestClass.replace_virtual_fields(:vref1)).to be_nil
           expect(TestClass.replace_virtual_fields(:ref1)).to eq(:ref1)
-          expect(TestClass.replace_virtual_fields([:vref1])).to eq([])
-          expect(TestClass.replace_virtual_fields([:vref1, :ref1])).to eq([:ref1])
-          expect(TestClass.replace_virtual_fields(:vref1 => {})).to eq({})
-          expect(TestClass.replace_virtual_fields(:vref1 => {}, :ref1 => {})).to eq(:ref1 => {})
+          expect(TestClass.replace_virtual_fields([:vref1].freeze)).to be_nil
+          expect(TestClass.replace_virtual_fields([:vref1, :ref1].freeze)).to eq(:ref1)
+          expect(TestClass.replace_virtual_fields({:vref1 => {}}.freeze)).to be_nil
+          expect(TestClass.replace_virtual_fields({:vref1 => {}, :ref1 => {}}.freeze)).to eq(:ref1)
         end
       end
     end
@@ -377,12 +377,12 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
           expect(test_sub_class.replace_virtual_fields(:vref1)).to be_nil
           expect(test_sub_class.replace_virtual_fields(:vrefsub1)).to be_nil
           expect(test_sub_class.replace_virtual_fields(:ref1)).to eq(:ref1)
-          expect(test_sub_class.replace_virtual_fields([:vref1])).to eq([])
-          expect(test_sub_class.replace_virtual_fields([:vrefsub1])).to eq([])
-          expect(test_sub_class.replace_virtual_fields([:vrefsub1, :vref1, :ref1])).to eq([:ref1])
-          expect(test_sub_class.replace_virtual_fields(:vref1 => {})).to eq({})
-          expect(test_sub_class.replace_virtual_fields(:vrefsub1 => {})).to eq({})
-          expect(test_sub_class.replace_virtual_fields(:vrefsub1 => {}, :vref1 => {}, :ref1 => {})).to eq(:ref1 => {})
+          expect(test_sub_class.replace_virtual_fields([:vref1].freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields([:vrefsub1].freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields([:vrefsub1, :vref1, :ref1].freeze)).to eq(:ref1)
+          expect(test_sub_class.replace_virtual_fields({:vref1 => {}}.freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields({:vrefsub1 => {}}.freeze)).to be_nil
+          expect(test_sub_class.replace_virtual_fields({:vrefsub1 => {}, :vref1 => {}, :ref1 => {}}.freeze)).to eq(:ref1)
         end
       end
     end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -524,17 +524,17 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
       expect(Author.replace_virtual_fields([:book_with_most_bookmarks, :books])).to eq([{:books => :bookmarks}, :books])
       expect(Author.replace_virtual_fields(["book_with_most_bookmarks", "books"])).to eq([{:books => :bookmarks}, :books])
       expect(Author.replace_virtual_fields([{:book_with_most_bookmarks => {}}, :books])).to eq([{:books => :bookmarks}, :books])
-      expect(Author.replace_virtual_fields([{:book_with_most_bookmarks => {}}, {:books => {}}])).to eq([{:books => :bookmarks}, {:books => {}}])
+      expect(Author.replace_virtual_fields([{:book_with_most_bookmarks => {}}, {:books => {}}])).to eq([{:books => :bookmarks}, :books])
     end
 
     it "handles hash form of delegates" do
-      expect(Book.replace_virtual_fields([{:author_name => {}}, {:author_name2 => {}}])).to eq([{:author => {}}, {:author => {}}])
+      expect(Book.replace_virtual_fields([{:author_name => {}}, {:author_name2 => {}}])).to eq([:author, :author])
     end
 
     it "handles non-'includes' virtual_attributes" do
       expect(Author.replace_virtual_fields(:nick_or_name)).to eq(nil)
-      expect(Author.replace_virtual_fields([:nick_or_name])).to eq([])
-      expect(Author.replace_virtual_fields(:nick_or_name => {})).to eq({})
+      expect(Author.replace_virtual_fields([:nick_or_name])).to eq(nil)
+      expect(Author.replace_virtual_fields(:nick_or_name => {})).to eq(nil)
     end
 
     it "handles deep includes with va indirect uses(:uses => :books => :bookmarks)" do
@@ -543,7 +543,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
     it "handles arrays" do
       value = Author.includes(:named_books).includes_values
-      expect(Author.replace_virtual_fields(value)).to eq([[:books]])
+      expect(Author.replace_virtual_fields(value)).to eq(:books)
     end
   end
 

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -540,6 +540,11 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "handles deep includes with va indirect uses(:uses => :books => :bookmarks)" do
       expect(Author.replace_virtual_fields(:famous_co_authors => {})).to eq({:books => {:bookmarks => {}, :co_authors => {}}})
     end
+
+    it "handles arrays" do
+      value = Author.includes(:named_books).includes_values
+      expect(Author.replace_virtual_fields(value)).to eq([[:books]])
+    end
   end
 
   def preloaded(records, associations, preload_scope = nil)


### PR DESCRIPTION
`relace_virtual_field` sometimes returns unnecessary tiers of embedded hashes or arrays. E.g. `[[:field]]` instead of `:field`.

6.1 has one fixes, but is by no means exhaustive:

```ruby
association = association.first if association.kind_of?(Array) && association.size == 1
```

This fixes `replace_virtual_field` to not output that value. Since this is at the return of each level, it essentially applied recursively and flattens it significantly.

Added `freeze` in tests to verify that the input parameter is unmodified.