### PR TITLE
Resolve rubocops

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -9,18 +9,20 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Keenan Brock"]
   spec.email         = ["keenan@thebrocks.net"]
 
-  spec.summary       = %q{Access non-sql attributes from sql}
-  spec.description   = %q{Define attributes in arel}
+  spec.summary       = "Access non-sql attributes from sql"
+  spec.description   = "Define attributes in arel"
   spec.homepage      = "https://github.com/ManageIQ/activerecord-virtual_attributes"
   spec.license       = "Apache 2.0"
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/ManageIQ/activerecord-virtual_attributes"
-  spec.metadata["changelog_uri"] = "https://github.com/ManageIQ/activerecord-virtual_attributes/blob/master/CHANGELOG.md"
-  spec.metadata['rubygems_mfa_required'] = "true"
+  spec.metadata      = {
+    "homepage_uri"          => spec.homepage,
+    "source_code_uri"       => "https://github.com/ManageIQ/activerecord-virtual_attributes",
+    "changelog_uri"         => "https://github.com/ManageIQ/activerecord-virtual_attributes/blob/master/CHANGELOG.md",
+    "rubygems_mfa_required" => "true"
+  }
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 

--- a/bin/console
+++ b/bin/console
@@ -8,7 +8,7 @@ Dir['./spec/support/**/*.rb'].sort.select { |f| !File.read(f).include?("RSpec") 
 
 # models for local testing
 Database.new.setup.migrate
-require_relative "../seed.rb"
+require_relative "../seed"
 
 require "irb"
 IRB.start(__FILE__)

--- a/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
+++ b/lib/active_record/virtual_attributes/rspec/have_virtual_attribute.rb
@@ -1,4 +1,4 @@
-RSpec::Matchers.define :have_virtual_attribute do |name, type|
+RSpec::Matchers.define(:have_virtual_attribute) do |name, type|
   match do |klass|
     expect(klass.has_attribute?(name)).to be_truthy
     expect(klass.virtual_attribute?(name)).to be_truthy

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -74,12 +74,13 @@ module ActiveRecord
           type = options[:type] || to_ref.klass.type_for_attribute(col)
           type = ActiveRecord::Type.lookup(type) if type.kind_of?(Symbol)
           raise "unknown attribute #{to}##{col} referenced in #{name}" unless type
+
           arel = virtual_delegate_arel(col, to_ref)
           define_virtual_attribute(method_name, type, :uses => (options[:uses] || to), :arel => arel)
         end
 
         # see activesupport module/delegation.rb
-        def define_delegate(method_name, method, to: nil, allow_nil: nil, default: nil)
+        def define_delegate(method_name, method, to: nil, allow_nil: nil, default: nil) # rubocop:disable Naming/MethodParameterName
           location = caller_locations(2, 1).first
           file, line = location.path, location.lineno
 
@@ -125,7 +126,7 @@ module ActiveRecord
           module_eval(method_def, file, line)
         end
 
-        def virtual_delegate_name_prefix(prefix, to)
+        def virtual_delegate_name_prefix(prefix, to) # rubocop:disable Naming/MethodParameterName
           "#{prefix == true ? to : prefix}_" if prefix
         end
 

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -5,6 +5,7 @@ module ActiveRecord
       include ActiveRecord::VirtualAttributes
       include ActiveRecord::VirtualAttributes::VirtualReflections
 
+      # rubocop:disable Style/SingleLineMethods
       module NonARModels
         def dangerous_attribute_method?(_); false; end
 
@@ -14,6 +15,7 @@ module ActiveRecord
 
         def belongs_to_required_by_default; false; end
       end
+      # rubocop:enable Style/SingleLineMethods
 
       included do
         unless respond_to?(:dangerous_attribute_method?)

--- a/lib/active_record/virtual_attributes/virtual_reflections.rb
+++ b/lib/active_record/virtual_attributes/virtual_reflections.rb
@@ -17,7 +17,7 @@ module ActiveRecord
         end
 
         def virtual_has_many(name, options = {})
-          define_method("#{name.to_s.singularize}_ids") do
+          define_method(:"#{name.to_s.singularize}_ids") do
             records = send(name)
             records.respond_to?(:ids) ? records.ids : records.collect(&:id)
           end
@@ -57,11 +57,11 @@ module ActiveRecord
         end
 
         def follow_associations(association_names)
-          association_names.inject(self) { |klass, name| klass.try!(:reflect_on_association, name).try!(:klass) }
+          association_names.inject(self) { |klass, name| klass&.reflect_on_association(name)&.klass }
         end
 
         def follow_associations_with_virtual(association_names)
-          association_names.inject(self) { |klass, name| klass.try!(:reflection_with_virtual, name).try!(:klass) }
+          association_names.inject(self) { |klass, name| klass&.reflection_with_virtual(name)&.klass }
         end
 
         # invalid associations return a nil
@@ -97,6 +97,7 @@ module ActiveRecord
 
         def add_virtual_reflection(reflection, name, uses, _options)
           raise ArgumentError, "macro must be specified" unless reflection
+
           reset_virtual_reflection_information
           _virtual_reflections[name.to_sym] = reflection
           define_virtual_include(name.to_s, uses)

--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -72,7 +72,7 @@ module VirtualAttributes
           if has_attribute?(name)
             self[name] || 0
           elsif (rel = send(relation)).loaded?
-            values = rel.map { |t| t.send(column) }.compact
+            values = rel.filter_map { |t| t.send(column) }
             if block_given?
               yield values
             else

--- a/seed.rb
+++ b/seed.rb
@@ -1,0 +1,3 @@
+Author.create_with_books(3)
+Author.create_with_books(4)
+Author.create_with_books(2)

--- a/spec/support/byebug.rb
+++ b/spec/support/byebug.rb
@@ -1,4 +1,5 @@
 begin
   require "byebug"
 rescue LoadError
+  # library not found
 end

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -34,7 +34,7 @@ class Database
     log.level = Logger::Severity::UNKNOWN
     ActiveRecord::Base.logger = log
 
-    @connection_options = YAML.safe_load(ERB.new(IO.read("#{dirname}/database.yml")).result)[self.class.adapter]
+    @connection_options = YAML.safe_load(ERB.new(File.read("#{dirname}/database.yml")).result)[self.class.adapter]
 
     self
   end

--- a/spec/support/with_test_class.rb
+++ b/spec/support/with_test_class.rb
@@ -21,10 +21,8 @@ RSpec.shared_context 'with test_class', :with_test_class do
 
     ActiveRecord::Schema.define do
       # rails method - can't do anything about this name
-      # rubocop:disable Naming/AccessorMethodName
       def self.set_pk_sequence!(*)
       end
-      # rubocop:enable Naming/AccessorMethodName
 
       self.verbose = false
 

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -556,7 +556,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
 
       before do
         # OperatingSystem (child)
-        class TestOtherClass < ActiveRecord::Base
+        class TestOtherClass < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
           def self.connection
             TestClassBase.connection
           end

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
   it "delegates to parent (sql)" do
     TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
     TestClass.create(:ref1 => parent)
-    tcs = TestClass.all.select(:id, :col1, TestClass.arel_table[:parent_col1].as("x"))
+    tcs = TestClass.select(:id, :col1, TestClass.arel_table[:parent_col1].as("x"))
     expect(tcs.map(&:x)).to match_array([nil, 4])
   end
 
@@ -80,7 +80,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     it "delegates to child (sql)" do
       TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
       tc = TestClass.create(:ref2 => child)
-      tcs = TestClass.all.select(:id, :col1, :child_col1).to_a
+      tcs = TestClass.select(:id, :col1, :child_col1).to_a
       expect { expect(tcs.map(&:child_col1)).to match_array([nil, tc.id]) }.to_not make_database_queries
     end
 
@@ -88,7 +88,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     # just want to make sure it changed due to intentional changes
     it "uses table alias for subquery" do
       TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
-      sql = TestClass.all.select(:id, :col1, :child_col1).to_sql
+      sql = TestClass.select(:id, :col1, :child_col1).to_sql
       expect(sql).to match(/["`]test_classes_[^"`]*["`][.]["`]col1["`]/i)
     end
   end
@@ -105,7 +105,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     it "properly generates sub select" do
       TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
       TestClass.create(:ref2 => child)
-      expect { TestClass.all.select(:id, :child_col1).to_a }.to_not raise_error
+      expect { TestClass.select(:id, :child_col1).to_a }.to_not raise_error
     end
   end
 
@@ -122,7 +122,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     it "properly generates sub select" do
       TestClass.virtual_delegate :col1, :prefix => 'child', :to => :ref2
       TestClass.create(:ref2 => child)
-      expect { TestClass.all.select(:id, :child_col1).to_a }.to_not raise_error
+      expect { TestClass.select(:id, :child_col1).to_a }.to_not raise_error
     end
   end
 
@@ -177,10 +177,10 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       TestOtherClass.virtual_delegate :col1, :to => :oref1
       TestOtherClass.create(:oref1 => TestClass.create)
       TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
-      tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_table[:col1].as("x"))
+      tcs = TestOtherClass.select(:id, :ocol1, TestOtherClass.arel_table[:col1].as("x"))
       expect(tcs.map(&:x)).to match_array([nil, 99])
 
-      expect { tcs = TestOtherClass.all.select(:id, :ocol1, :col1).load }.to make_database_queries(:count => 1)
+      expect { tcs = TestOtherClass.select(:id, :ocol1, :col1).load }.to make_database_queries(:count => 1)
       expect(tcs.map(&:col1)).to match_array([nil, 99])
     end
 
@@ -188,7 +188,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     # just want to make sure it changed due to intentional changes
     it "delegates to another table without alias" do
       TestOtherClass.virtual_delegate :col1, :to => :oref1
-      sql = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_table[:col1].as("x")).to_sql
+      sql = TestOtherClass.select(:id, :ocol1, TestOtherClass.arel_table[:col1].as("x")).to_sql
       expect(sql).to match(/["`]test_classes["`].["`]col1["`]/i)
     end
 
@@ -196,7 +196,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       TestOtherClass.virtual_delegate :col1, :to => :oref1, :type => :integer
       TestOtherClass.create(:oref1 => TestClass.create)
       TestOtherClass.create(:oref1 => TestClass.create(:col1 => 99))
-      tcs = TestOtherClass.all.select(:id, :ocol1, TestOtherClass.arel_table[:col1].as("x"))
+      tcs = TestOtherClass.select(:id, :ocol1, TestOtherClass.arel_table[:col1].as("x"))
       expect(tcs.map(&:x)).to match_array([nil, 99])
     end
 

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -224,7 +224,10 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
   it "preloads virtual_attribute in :include when :conditions are also present in calculations" do
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.name = '#{author_name}'")).to preload_values(:author_name, author_name)
     expect(Book.includes([:author_name, :author]).references(:author).where(:authors => {:name => author_name})).to preload_values(:author_name, author_name)
+    # Disable Rails/WhereNot because we are testing this specific use case
+    # rubocop:disable Rails/WhereNot
     expect(Book.includes([:author_name, :author]).references(:author).where("authors.id IS NOT NULL")).to preload_values(:author_name, author_name)
+    # rubocop:enable Rails/WhereNot
     expect(Book.includes([:author_name, :author]).references(:author).where.not(:authors => {:id => nil})).to preload_values(:author_name, author_name)
   end
 
@@ -290,13 +293,13 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
     it "preloads through association" do
       books = preloaded(Book.all.to_a, :author => :total_books)
-      expect { books.map(&:author).map(&:total_books) }.to_not make_database_queries
+      expect { books.map { |book| book.author.total_books } }.to_not make_database_queries
     end
 
     it "doesn't preloads through polymorphic" do ##
       # not sure what is expected to happen for preloading a column (that is not standard rails) use select instead
       a = preloaded(Book.all.to_a, :author_or_bookmark => :total_books)
-      expect { a.map(&:author_or_bookmark).map(&:total_books) }.to_not make_database_queries
+      expect { a.map { |book| book.author_or_bookmark.total_books } }.to_not make_database_queries
     end
 
     it "uses included associations" do

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
     it "falls back to default when virtual association is not written correctly in ruby" do
       a = model_with_children(0)
-      # note: this is breaking the return to return nil. (it should return [] / none)
+      # NOTE: this is intentionally breaking the return to return nil. (it should return [] / none)
       # some of our associations (virtual) are broken.
       expect(a).to receive(:named_books).and_return(nil)
 


### PR DESCRIPTION
Now may be a good time to push these - as we will be ramping up our testing

None of these overlap with the active record 7.0 changes

I skipped a number of warnings around parenthesis. I felt they assisted the code. Also avoided changing the variable `to`, as with delegation, that is the correct phrase.

```
< 32 files inspected, 87 offenses detected, 58 offenses autocorrectable
---
33 files inspected, 51 offenses detected, 27 offenses autocorrectable
```