### PR TITLE
drop virtual_aggregate

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_total.rb
+++ b/lib/active_record/virtual_attributes/virtual_total.rb
@@ -49,35 +49,6 @@ module VirtualAttributes
         define_virtual_aggregate_method(name, relation, column, :average) { |values| values.count == 0 ? 0 : values.sum / values.count }
       end
 
-      #  @param method_name
-      #    :count :average :minimum :maximum :sum
-      #
-      #  example:
-      #
-      #    class Hardware
-      #      has_many :disks
-      #      virtual_sum :allocated_disk_storage, :disks, :size
-      #    end
-      #
-      #    generates:
-      #
-      #    def allocated_disk_storage
-      #      if disks.loaded?
-      #        disks.map(&:size).compact.sum
-      #      else
-      #        disks.sum(:size) || 0
-      #      end
-      #    end
-      #
-      #    virtual_attribute :allocated_disk_storage, :integer, :uses => :disks, :arel => ...
-      #
-      #    # arel => (SELECT sum("disks"."size") where "hardware"."id" = "disks"."hardware_id")
-
-      def virtual_aggregate(name, relation, method_name = :sum, column = nil, options = {})
-        return virtual_total(name, relation, options) if method_name == :size
-        return virtual_sum(name, relation, column, options) if method_name == :sum
-      end
-
       def define_virtual_aggregate_attribute(name, relation, method_name, column, options)
         reflection = reflect_on_association(relation)
 


### PR DESCRIPTION
We went from virtual_aggregate :sum to virtual_sum years ago. (5.0 time frame?)

extracted from #151 

removed in https://github.com/ManageIQ/manageiq/pull/20572

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
