### PR TITLE
Drop attributes_builder

### DIFF
--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -83,14 +83,6 @@ module ActiveRecord
         end
       end
 
-      def attributes_builder # :nodoc:
-        unless defined?(@attributes_builder) && @attributes_builder
-          defaults = _default_attributes.except(*(column_names - [primary_key]))
-          @attributes_builder = ActiveModel::AttributeSet::Builder.new(attribute_types, defaults)
-        end
-        @attributes_builder
-      end
-
       private
 
       def load_schema!


### PR DESCRIPTION
extracted from #150 

in f53272a9 we removed 5.1 support, so no longer needed to override this method Should have deleted this method

I had expected some exclusion for virtual attributes, but stock has been working since 5.2, so letting it slide
