### PR TITLE
Don't run preloader on double arrays

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -159,7 +159,7 @@ module ActiveRecord
           records_by_assoc.each do |klass_associations, klass_records|
             next if klass_associations.blank?
 
-            Array[klass_associations].each do |klass_association| # rubocop:disable Style/RedundantArrayConstructor
+            Array.wrap(klass_associations).each do |klass_association|
               # this calls back into itself, but it will take the short circuit
               Preloader.new(:records => klass_records, :associations => klass_association, :scope => scope).call
             end


### PR DESCRIPTION
This is an optimization.

`klass_associations` needs to be an array.
It can be a `nil, symbol, Array` or `Hash`.

The `nil` case is handled by `blank?`.
The `Symbol` and `Hash` are converted to an `Array`
But the `Array` was being converted to a double `Array`.

Which was not horrible, but just calls a loader then another loader.

With this change, the loader only runs through the association once.