### PR TITLE
Remove sql logger setup from specs

### DIFF
--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -28,12 +28,6 @@ class Database
       I18n.enforce_available_locales = false if I18n.respond_to?(:enforce_available_locales=)
       # I18n.fallbacks = [I18n.default_locale] if I18n.respond_to?(:fallbacks=)
     end
-    log = Logger.new(STDERR)
-    # log = Logger.new('db.log')
-    # log.sev_threshold = Logger::DEBUG
-    log.level = Logger::Severity::UNKNOWN
-    ActiveRecord::Base.logger = log
-
     @connection_options = YAML.safe_load(ERB.new(File.read("#{dirname}/database.yml")).result)[self.class.adapter]
 
     self


### PR DESCRIPTION
Before
------

I like to put sql logging configuration in supports.
With this code here, I am not able to do that.

After
-----

No more setup code. I can now put my logging code of choice anywhere in `spec/support`
