### PR TITLE
pass all parameters to preloader children

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -161,7 +161,7 @@ module ActiveRecord
 
             Array.wrap(klass_associations).each do |klass_association|
               # this calls back into itself, but it will take the short circuit
-              Preloader.new(:records => klass_records, :associations => klass_association, :scope => scope).call
+              Preloader.new(:records => klass_records, :associations => klass_association, :scope => scope, :available_records => @available_records, :associate_by_default => @associate_by_default).call
             end
           end
         end


### PR DESCRIPTION
This passes all the parameters from the preloader into the new preloader.

This was causing a problem in manageiq preloader specs.

Unfortunately, I do not fully understand these parameters, I just know we want to pass them all.
And I'm no longer able to reproduce the issue.

But not passing these along seems like a mistake