### PR TITLE
Remove test files from packaged gem

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|bin)/}) || f.match(/^(\.)|renovate.json/) }
   end
 
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Goal
----

I just ran into issues with an exploded gem having a `.rubcop.yml` file.
Seems we shouldn't ship these.

So I removed unnecessary files.

Details
-------

Not sure what is classified as necessary.

- In the lists below, I lumped all `lib/*` files together to make it more readable.
- The `bin/*` files are for development. So I think they are not needed for distribution.
- Do we want to keep the `Rakefile` or `Gemfile`? Left in for now.

Before
------

[".codeclimate.yml",
 ".github/workflows/ci.yaml",
 ".gitignore",
 ".rspec",
 ".rubocop.yml",
 ".rubocop_cc.yml",
 ".rubocop_local.yml",
 ".whitesource",
 ".yamllint",
 "CHANGELOG.md",
 "Gemfile",
 "LICENSE.txt",
 "README.md",
 "Rakefile",
 "activerecord-virtual_attributes.gemspec",
 "bin/console",
 "bin/setup",
 "init.rb",
 "lib/*",
 "renovate.json",
 "seed.rb"]

After
-----

["CHANGELOG.md",
 "Gemfile",
 "LICENSE.txt",
 "README.md",
 "Rakefile",
 "activerecord-virtual_attributes.gemspec",
 "init.rb",
 "lib/*"]

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
