### PR TITLE
move seed into bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -8,7 +8,11 @@ Dir['./spec/support/**/*.rb'].sort.select { |f| !File.read(f).include?("RSpec") 
 
 # models for local testing
 Database.new.setup.migrate
-require_relative "../seed"
+
+# data for local testing
+Author.create_with_books(3)
+Author.create_with_books(4)
+Author.create_with_books(2)
 
 require "irb"
 IRB.start(__FILE__)

--- a/seed.rb
+++ b/seed.rb
@@ -1,3 +1,0 @@
-Author.create_with_books(3)
-Author.create_with_books(4)
-Author.create_with_books(2)


### PR DESCRIPTION
Goal
-----

Cut down on the clutter in the home directory

There is a `seed.rb` file, but it seems like overkill to keep this around.


Seed purpose
-------------

I run `bin/console` on sqlite to see the sql or how something runs. Every time going in there, I need to to seed data. The actual values don't matter, just that there is data.

I rarely use `postgres` and tend to use sqlite. The exception is when I'm trying to fix this `ORDER BY` but with `DISTINCT` columns - which only shows up for postgres and mysql databases.

Alternative solutions
------------

I did try moving seeding into `spec/supports`, but this gem loads the supports files before defining the models and connecting to the database.

In a perfect world, I could define seed data in the supports directory to be loaded when the database is created and calls a hook.