### PR TITLE
Rails 7.1 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,9 +12,10 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '2.7'
-        - '3.0'
         - '3.1'
+        - '3.2'
+        - '3.3'
+        - '3.4'
     services:
       postgres:
         image: postgres:13

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~>7.0.8"
+gem "activerecord", "~>7.1.5"
 gem "mysql2"
 gem "pg"
 gem "sqlite3", "< 2"

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -271,11 +271,11 @@ module ActiveRecord
       def self.select_from_alias_table(to_klass, src_relation)
         to_table = to_klass.arel_table
         # if a self join, alias the second table to a different name
-        if to_table.table_name == src_relation.table_name
+        if to_table.name == src_relation.name
           # use a dup to not modify the primary table in the model
           to_table = to_table.dup
           # use a table alias to not conflict with table name in the primary query
-          to_table.table_alias = "#{to_table.table_name}_sub"
+          to_table.instance_variable_set(:@table_alias, "#{to_table.name}_sub")
         end
         to_table
       end

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -272,10 +272,8 @@ module ActiveRecord
         to_table = to_klass.arel_table
         # if a self join, alias the second table to a different name
         if to_table.name == src_relation.name
-          # use a dup to not modify the primary table in the model
-          to_table = to_table.dup
           # use a table alias to not conflict with table name in the primary query
-          to_table.instance_variable_set(:@table_alias, "#{to_table.name}_sub")
+          to_table = to_table.alias("#{to_table.name}_sub")
         end
         to_table
       end


### PR DESCRIPTION
* Support Rails 7.1 only on master
* Add ruby 3.2-3.4 to the test matrix, drop 2.7-3.0.

* Rails 7.1 removed the table_name alias to name so just use name:
See: https://www.github.com/rails/rails/pull/46864

* Rails 7.1 removed the writer for the table_alias so set the instance
variable.  Since they dropped the table_alias writer on the Arel::Table, we're
no longer modifying it so we can drop the dup.
See: https://www.github.com/rails/rails/pull/48927