### PR TITLE
Drop openstruct

### DIFF
--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -1,5 +1,3 @@
-require "ostruct"
-
 RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
   context "TestClass", :with_test_class do
     it "should not have any virtual columns" do
@@ -248,27 +246,31 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
 
     describe "#virtual_has_many" do
       it "use collect for virtual_ids column" do
-        c = Class.new(TestClassBase) do
-          self.table_name = 'test_classes'
-          virtual_has_many(:hosts)
-          def hosts
-            [OpenStruct.new(:id => 5), OpenStruct.new(:id => 6)]
+        c = Class.new(Author) do
+          virtual_has_many :local_books
+
+          def local_books
+            [Book.new(:id => 5), Book.new(:id => 6)]
           end
         end.new
 
-        expect(c.host_ids).to eq([5, 6])
+        expect(c.local_book_ids).to eq([5, 6])
       end
 
       it "use Relation#ids for virtual_ids column" do
-        c = Class.new(TestClassBase) do
-          self.table_name = 'test_classes'
-          virtual_has_many(:hosts)
-          def hosts
-            OpenStruct.new(:ids => [5, 6])
+        c = Class.new(Author) do
+          virtual_has_many(:local_books)
+
+          def local_books
+            Class.new do
+              def ids
+                [5, 6]
+              end
+            end.new
           end
         end.new
 
-        expect(c.host_ids).to eq([5, 6])
+        expect(c.local_book_ids).to eq([5, 6])
       end
     end
 
@@ -402,7 +404,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
         let(:test_sub_class) do
           Class.new(TestClass) do
             def self.reflections
-              super.merge(:ref2 => OpenStruct.new(:name => :ref2, :options => {}, :klass => TestClass))
+              super.merge(:ref2 => ActiveRecord::Reflection::BelongsToReflection.new(:ref2, nil, {}, TestClass))
             end
 
             virtual_has_one :vrefsub1


### PR DESCRIPTION
openstruct is no longer in the standard library
Could have gone with using `double()` but then it is just swapping one mock for another.
Since we only use it in a few spots, just removed it.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
