### PR TITLE
Pin concurrent-ruby to < 1.3.5 until we're on rails 7.1

### DIFF
--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -28,7 +28,9 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 7.0"
+  spec.add_dependency "concurrent-ruby", "< 1.3.5" # Temporary pin down as concurrent-ruby 1.3.5 breaks Rails 7.0, and rails-core doesn't
+                                                   # plan to ship a new 7.0 to fix it. See https://github.com/rails/rails/pull/54264
+  spec.add_runtime_dependency "activerecord", "~> 7.0", ">=7.0.8.7"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "database_cleaner-active_record", "~> 2.1"


### PR DESCRIPTION
See core PR:
https://github.com/ManageIQ/manageiq/pull/23310

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
