### PR TITLE
Require type for delegation

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -81,6 +81,7 @@ module ActiveRecord
           # On the other hand it could be that the target has side-effects,
           # whereas conceptually, from the user point of view, the delegator should
           # be doing one call.
+          # NOTE: This is based upon ActiveSupport 6.0 delegate.rb, but we added has_attribute? and default
           if allow_nil
             method_def = <<-METHOD
               def #{method_name}(#{definition})

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -1,4 +1,4 @@
-class VirtualTotalTestBase < ActiveRecord::Base  # rubocop:disable Rails/ApplicationRecord
+class VirtualTotalTestBase < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   self.abstract_class = true
 
   include VirtualFields

--- a/spec/support/with_test_class.rb
+++ b/spec/support/with_test_class.rb
@@ -13,7 +13,7 @@ require 'active_record'
 #
 RSpec.shared_context 'with test_class', :with_test_class do
   before do
-    class TestClassBase < ActiveRecord::Base
+    class TestClassBase < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
       self.abstract_class = true
 
       include VirtualFields

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
     end
 
     context "add_virtual_reflection integration" do
-      it "with invalid parameters" do
+      it "expects an association name" do
         expect { TestClass.virtual_has_one }.to raise_error(ArgumentError)
       end
 
@@ -218,17 +218,17 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
         expect(TestClass.virtual_reflection(:vref1).name).to eq(:vref1)
       end
 
-      it("with has_one macro") do
+      it "with has_one macro" do
         TestClass.virtual_has_one(:vref1)
         expect(TestClass.virtual_reflection(:vref1).macro).to eq(:has_one)
       end
 
-      it("with has_many macro") do
+      it "with has_many macro" do
         TestClass.virtual_has_many(:vref1)
         expect(TestClass.virtual_reflection(:vref1).macro).to eq(:has_many)
       end
 
-      it("with belongs_to macro") do
+      it "with belongs_to macro" do
         TestClass.virtual_belongs_to(:vref1)
         expect(TestClass.virtual_reflection(:vref1).macro).to eq(:belongs_to)
       end

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
     end
 
     context ".virtual_column" do
-      it "with invalid parameters" do
-        expect { TestClass.virtual_column :vcol1 }.to raise_error(ArgumentError)
+      it "expects a :type parameter" do
+        expect { TestClass.virtual_column :vcol1 }.to raise_error(ArgumentError, /missing keyword: :type/)
       end
 
       it "with symbol name" do

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -40,14 +40,15 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
   context "invalid" do
     it "expects a ':to' for delegation" do
       expect do
-        TestClass.virtual_delegate :col1
+        TestClass.virtual_delegate :col1, :type => :integer
       end.to raise_error(ArgumentError, /missing keyword: :to/)
     end
 
     it "expects a ':type' for delegation" do
-      expect(ActiveRecord::VirtualAttributes.deprecator).to receive(:warn).with(/type/, anything)
-      TestClass.virtual_delegate :col1, :to => :ref1
-      TestClass.new
+      expect do
+        TestClass.virtual_delegate :col1, :to => :ref1
+        TestClass.new
+      end.to raise_error(ArgumentError, /missing keyword: :type/)
     end
 
     it "only allows 1 method when delegating to a specific method" do


### PR DESCRIPTION
We used to derive the type for delegates.

But this causes our "Constant Problem" when loading the relation and reared it's head as random deadlocks.

No longer support this functionality

I had changed all references to declare the `:type` in the past, but a few have snuck back in. Will run cross repo and fix them before merging this one.

- https://github.com/ManageIQ/activerecord-virtual_attributes/pull/21
- #188
