### PR TITLE
Deprecate message when virtual_delegate is not passed type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The versioning of this gem follows ActiveRecord versioning, and does not follow 
 
 ## [Unreleased]
 
+## [7.1.1] - 2025-06-18
+
+* Deprecate virtual_delegate without a type [#188](https://github.com/ManageIQ/activerecord-virtual_attributes/pull/188)
+
 ## [7.1.0] - 2025-02-19
 
 * Use TableAlias for table aliasing [#168](https://github.com/ManageIQ/activerecord-virtual_attributes/pull/168)
@@ -111,7 +115,8 @@ The versioning of this gem follows ActiveRecord versioning, and does not follow 
 * Initial Release
 * Extracted from ManageIQ/manageiq
 
-[Unreleased]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.1.0...HEAD
+[Unreleased]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.1.1...HEAD
+[7.1.1]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.1.0...v7.1.1
 [7.1.0]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.0.0...v7.1.0
 [7.0.0]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v6.1.2...v7.0.0
 [6.1.2]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v6.1.1...v6.1.2

--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -1,6 +1,7 @@
 require "active_support/concern"
 require "active_record"
 
+require "active_record/virtual_attributes/version"
 require "active_record/virtual_attributes/virtual_includes"
 require "active_record/virtual_attributes/virtual_arel"
 require "active_record/virtual_attributes/virtual_delegates"
@@ -36,6 +37,10 @@ module ActiveRecord
     ActiveRecord::Type.register(:numeric_set, Type::NumericSet)
     ActiveRecord::Type.register(:string_set, Type::StringSet)
     ActiveRecord::Type.register(:symbol, Type::Symbol)
+
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new(ActiveRecord::VirtualAttributes::VERSION, "virtual_attributes")
+    end
 
     included do
       class_attribute :virtual_attributes_to_define, :instance_accessor => false, :default => {}

--- a/lib/active_record/virtual_attributes/version.rb
+++ b/lib/active_record/virtual_attributes/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module VirtualAttributes
-    VERSION = "7.1.0".freeze
+    VERSION = "7.1.1".freeze
   end
 end

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -24,6 +24,10 @@ module ActiveRecord
             raise ArgumentError, 'Delegation needs an association. Supply an options hash with a :to key as the last argument (e.g. delegate :hello, to: :greeter).'
           end
 
+          unless options[:type]
+            ActiveRecord::VirtualAttributes.deprecator.warn("Calling virtual_delegate without :type is now deprecated", caller)
+          end
+
           to = to.to_s
           if to.include?(".") && methods.size > 1
             raise ArgumentError, 'Delegation only supports specifying a method name when defining a single virtual method'

--- a/spec/virtual_attributes_spec.rb
+++ b/spec/virtual_attributes_spec.rb
@@ -482,7 +482,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
       end
 
       it "supports delegates" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
       end
@@ -530,7 +530,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
       end
 
       it "supports delegates" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
 
         expect(TestClass.attribute_supported_by_sql?(:parent_col1)).to be_truthy
       end
@@ -598,42 +598,42 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualFields do
       let(:parent) { TestClass.create(:col1 => 4) }
 
       it "delegates to child" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         tc = TestClass.new(:ref1 => parent)
         expect(tc.parent_col1).to eq(4)
       end
 
       it "delegates to nil child" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to be_nil
       end
 
       it "defines virtual attribute" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :type => :integer
         expect(TestClass.virtual_attribute_names).to include("parent_col1")
       end
 
       it "defines with a new name" do
-        TestClass.virtual_delegate 'funky_name', :to => "ref1.col1"
+        TestClass.virtual_delegate 'funky_name', :to => "ref1.col1", :type => :integer
         tc = TestClass.new(:ref1 => parent)
         expect(tc.funky_name).to eq(4)
       end
 
       it "defaults for to nil child (array)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => []
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => [], :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to eq([])
       end
 
       it "defaults for to nil child (integer)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => 0
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => 0, :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to eq(0)
       end
 
       it "defaults for to nil child (string)" do
-        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => "def"
+        TestClass.virtual_delegate :col1, :prefix => 'parent', :to => :ref1, :allow_nil => true, :default => "def", :type => :integer
         tc = TestClass.new
         expect(tc.parent_col1).to eq("def")
       end


### PR DESCRIPTION
This will be part of 7.1.1

We are deprecating the use of virtual_delegate without defining the type

This can (and has) caused deadlocks. Dropping this unsafe behavior.

It will be dropped in 7.2

---

I had thought there was `ActiveRecord::Deprecation.warn`, but in 7.1, that is deprecated.
When we upgrade to 7.2, we will no longer need this deprecation code.
