### PR TITLE
Nitpicks

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -191,6 +191,7 @@ module ActiveRecord
           # rubocop:enable Lint/AmbiguousOperatorPrecedence
 
           # branched.rb 7.0
+          # rubocop:disable Style/MultilineBlockChain
           def preloaders_for_reflection(reflection, reflection_records)
             reflection_records.group_by do |record|
               # begin virtual_attributes changes
@@ -212,6 +213,7 @@ module ActiveRecord
             end
           end
         end)
+        # rubocop:enable Style/MultilineBlockChain
       end
     end
   end

--- a/lib/active_record/virtual_attributes/virtual_reflections.rb
+++ b/lib/active_record/virtual_attributes/virtual_reflections.rb
@@ -14,12 +14,12 @@ module ActiveRecord
           add_virtual_reflection(reflection, name, uses)
         end
 
-        def virtual_has_many(name, uses: nil, source: nil, through: nil, **options)
+        def virtual_has_many(name, uses: nil, source: name, through: nil, **options)
           define_method(:"#{name.to_s.singularize}_ids") do
             records = send(name)
             records.respond_to?(:ids) ? records.ids : records.collect(&:id)
           end
-          define_delegate(name, source || name, :to => through, :allow_nil => true, :default => []) if through
+          define_delegate(name, source, :to => through, :allow_nil => true, :default => []) if through
           reflection = ActiveRecord::Associations::Builder::HasMany.build(self, name, nil, options)
           add_virtual_reflection(reflection, name, uses)
         end

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -116,7 +116,7 @@ class Author < VirtualTotalTestBase
   virtual_has_many :famous_co_authors, :uses => [:book_with_most_bookmarks, {:books => :co_authors}]
 
   def self.create_with_books(count)
-    create!(:name => "foo").tap { |author| author.create_books(count) }
+    create!(:name => "foo", :blurb => "blah blah blah").tap { |author| author.create_books(count) }
   end
 
   def create_books(count, create_attrs = {})
@@ -147,6 +147,9 @@ class Book < VirtualTotalTestBase
   virtual_delegate :name, :to => :author, :prefix => true, :type => :string
   # this tests delegates to named child attribute
   virtual_delegate :author_name2, :to => "author.name", :type => :string
+  # delegate without a prefix
+  virtual_delegate :blurb, :to => :author, :type => :string
+
   # delegate to a polymorphic
   virtual_delegate :description, :to => :current_photo, :prefix => true, :type => :string, :allow_nil => true
 

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -7,6 +7,7 @@ ActiveRecord::Schema.define(:version => 0) do
     t.integer  "teacher_id", :index => true
     t.string   "name"
     t.string   "nickname"
+    t.string   "blurb"
   end
 
   create_table "books", :force => true do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,7 @@ if ENV['CI']
   end
 end
 
-$LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib')
-
+$LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
 require "bundler/setup"
 require "active_record/virtual_attributes"
 require "active_record/virtual_attributes/rspec"

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
   let(:author_name) { "foo" }
   let(:book_name) { "bar" }
+  let(:blurb_text) { "blah blah blah" }
+
   # NOTE: each of the 1 authors has an array of books. so this value is [[Book, Book]]
   let(:named_books) { [Book.where.not(:name => nil).order(:id).load] }
 
@@ -41,8 +43,8 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "preloads virtual_attribute (:uses => :author, :uses => :author)" do
-      expect(Book.includes(:author_name, :author_name2)).to preload_values(:author_name, author_name)
-      expect(Book.includes(:author_name2 => {})).to preload_values(:author_name, author_name)
+      expect(Book.includes(:author_name, :blurb)).to preload_values(:author_name, author_name)
+      expect(Book.includes(:author_name => {})).to preload_values(:blurb, blurb_text)
     end
 
     it "preloads virtual_attribute (:uses => :upper_author_name) (:uses => :author_name)" do
@@ -526,7 +528,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     end
 
     it "handles hash form of delegates" do
-      expect(Book.replace_virtual_fields([{:author_name => {}}, {:author_name2 => {}}])).to eq([:author, :author])
+      expect(Book.replace_virtual_fields([{:author_name => {}}, {:blurb => {}}])).to eq([:author, :author])
     end
 
     it "handles non-'includes' virtual_attributes" do


### PR DESCRIPTION
1. rubocop around preloaders_for_reflection. this is a rails method and we don't want to modify them where possible
2. virtual_has_many defaults the `source` rather than modifying it in the code
3. rubocop `__FILE__` => `__dir__`
4. add delegate with no `prefix` declared.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
5. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
6. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
