### PR TITLE
[wip] use rails 8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '3.1'
-        - '3.2'
         - '3.3'
         - '3.4'
     services:
@@ -65,7 +63,7 @@ jobs:
           DB: mysql2
         run: bundle exec rake
       - name: Report code coverage
-        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.1' }}
+        if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '3.3' }}
         continue-on-error: true
         uses: paambaati/codeclimate-action@v9
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The versioning of this gem follows ActiveRecord versioning, and does not follow 
 
 ## [Unreleased]
 
+## [8.0.0.0] - 2025-07-10
+
+* Rails 8.0 support [#194](https://github.com/ManageIQ/activerecord-virtual_attributes/pull/194)
+
 ## [7.2.0.1] - 2025-07-18
 
 * Fix includes and associations with empty uses [#195](https://github.com/ManageIQ/activerecord-virtual_attributes/pull/195)

--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 7.2.2", ">=7.2.2.2"
+  spec.add_runtime_dependency "activerecord", "~> 8.0", ">= 8.0.2"
 
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "database_cleaner-active_record", "~> 2.1"
@@ -40,5 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
-  spec.add_development_dependency "sqlite3", "< 2"
+  spec.add_development_dependency "sqlite3", "~>2.1"
 end

--- a/lib/active_record/virtual_attributes/version.rb
+++ b/lib/active_record/virtual_attributes/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module VirtualAttributes
-    VERSION = "7.2.0.1".freeze
+    VERSION = "8.0.0.0".freeze
   end
 end


### PR DESCRIPTION
Started as a litmus test. But now I'm wondering

I'd be up for supporting 7.2 and 8.0 branches
May want to get the `virtual_attribute :through` changes into 7.2.1 before merging this / creating another branch

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
