### PR TITLE
Fix nil :uses issue when included through a polymorphic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The versioning of this gem follows ActiveRecord versioning, and does not follow 
 
 ## [Unreleased]
 
+## [7.2.0.1] - 2025-07-18
+
+* Fix includes and associations with empty uses [#195](https://github.com/ManageIQ/activerecord-virtual_attributes/pull/195)
+
 ## [7.2.0.0] - 2025-06-25
 
 * virtual_delegate requires type [#185](https://github.com/ManageIQ/activerecord-virtual_attributes/pull/185)
@@ -125,7 +129,8 @@ The versioning of this gem follows ActiveRecord versioning, and does not follow 
 * Initial Release
 * Extracted from ManageIQ/manageiq
 
-[Unreleased]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.2.0.0...HEAD
+[Unreleased]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.2.0.1...HEAD
+[7.2.0.1]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.2.0.0...v7.2.0.1
 [7.2.0.0]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.1.2...v7.2.0.0
 [7.1.2]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.1.1...v7.1.2
 [7.1.1]: https://github.com/ManageIQ/activerecord-virtual_attributes/compare/v7.1.0...v7.1.1

--- a/lib/active_record/virtual_attributes/version.rb
+++ b/lib/active_record/virtual_attributes/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module VirtualAttributes
-    VERSION = "7.2.0.0".freeze
+    VERSION = "7.2.0.1".freeze
   end
 end

--- a/lib/active_record/virtual_attributes/virtual_fields.rb
+++ b/lib/active_record/virtual_attributes/virtual_fields.rb
@@ -183,6 +183,7 @@ module ActiveRecord
             source_records.each do |record|
               # begin virtual_attributes changes
               association = record.class.replace_virtual_fields(self.association)
+              next if association.nil?
               # end virtual_attributes changes
 
               reflection = record.class._reflect_on_association(association)

--- a/spec/db/models.rb
+++ b/spec/db/models.rb
@@ -115,6 +115,12 @@ class Author < VirtualTotalTestBase
   #   vs a more condensed format: {:bwmb => {}, :books => co_a}
   virtual_has_many :famous_co_authors, :uses => [:book_with_most_bookmarks, {:books => :co_authors}]
 
+  virtual_has_many :thoughts
+
+  def thoughts
+    ["one", "two"]
+  end
+
   def self.create_with_books(count)
     create!(:name => "foo", :blurb => "blah blah blah").tap { |author| author.create_books(count) }
   end

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
     it "counts" do
       expect { expect(Author.includes(:books => :author_name).count).to eq(1) }.not_to raise_error
     end
+
+    # we are trying to get the includes with a nil uses to blow things up
+    it "preloads through polymorphic to an association without a uses" do
+      author = Author.first
+      photo = author.photos.create
+      expect(author.photos.includes(:imageable => :thoughts).first).to eq(photo)
+    end
   end
 
   # references follow a different path than just includes


### PR DESCRIPTION
When you `includes(:polymorphic => :attr)` and the `:attr` does not have a `:uses`,
this threw an exception.

Reason: Rails 7.2 added a `to_sym` in `reflect_on_association()`,
since `uses[:attr] = nil`, calling `reflect_on_association(nil)` had issues:

```
     Failure/Error: reflection = record.class._reflect_on_association(association)

     NoMethodError:
       undefined method `to_sym' for nil
     # /Users/kbrock/.gem/ruby/3.3.5/gems/activerecord-7.2.2.1/lib/active_record/reflection.rb:127:in `_reflect_on_association'
     # ./lib/active_record/virtual_attributes/virtual_fields.rb:189:in `block in grouped_records'
```

refs:
- https://github.com/rails/rails/issues/5172
- https://github.com/ManageIQ/manageiq-api/pull/1284
- https://github.com/ManageIQ/manageiq/issues/23518