### PR TITLE
spec wording, better error message for bogus va :through

### DIFF
--- a/lib/active_record/virtual_attributes.rb
+++ b/lib/active_record/virtual_attributes.rb
@@ -67,7 +67,7 @@ module ActiveRecord
           define_delegate(name, source, :to => through, :allow_nil => true, :default => default)
 
           unless (to_ref = reflection_with_virtual(through))
-            raise ArgumentError, "Delegation needs an association. Association #{through} does not exist"
+            raise ArgumentError, "#{self.name}.virtual_attribute #{name.inspect} references unknown :through association #{through.inspect}"
           end
 
           # ensure that the through table is in the uses clause

--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -31,14 +31,11 @@ module ActiveRecord
           # This better supports reloading of the class and changing the definitions
           methods.each do |method|
             method_name, to, method = determine_method_names(method, to, prefix)
-            unless (to_ref = reflection_with_virtual(to))
-              raise ArgumentError, "Delegation needs an association. Association #{to} does not exist"
-            end
 
             # NOTE: delete_blank will remove a default of []. we only want to remove nils
-            va_params = options.merge(:uses => uses, :through => to, :source => method, :default => default).delete_if {|n, v| v.nil? }
+            va_params = options.merge(:uses => uses, :through => to, :source => method, :default => default).delete_if { |_n, v| v.nil? }
 
-            ActiveRecord::VirtualAttributes.deprecator.warn("suggestion: #{name}.virtual_attribute #{method_name.inspect}, #{type.inspect}, #{va_params.map {|k, v| "#{k.inspect} => #{v.inspect}"}.join(", ")}", src_loc)
+            ActiveRecord::VirtualAttributes.deprecator.warn("suggestion: #{name}.virtual_attribute #{method_name.inspect}, #{type.inspect}, #{va_params.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(", ")}", src_loc)
             virtual_attribute(method_name, type, **va_params)
           end
         end

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       expect do
         TestClass.virtual_attribute :col1, :integer, :through => :bogus_ref
         TestClass.new
-      end.to raise_error(ArgumentError, /needs an association/)
+      end.to raise_error(ArgumentError, /references unknown :through association :bogus_ref/)
     end
 
     # currently, we can not detect a bad source

--- a/spec/virtual_delegates_spec.rb
+++ b/spec/virtual_delegates_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
       TestClass.virtual_attribute :child_col1, :integer, :through => :ref2, :source => :col1
       tc = TestClass.create(:ref2 => child)
       tcs = TestClass.select(:id, :col1, :child_col1).to_a
-      expect { expect(tcs.map(&:child_col1)).to match_array([nil, tc.id]) }.to_not make_database_queries
+      expect { expect(tcs.map(&:child_col1)).to match_array([nil, tc.id]) }.not_to make_database_queries
     end
 
     # this may fail in the future as our way of building queries may change
@@ -117,7 +117,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     it "properly generates sub select" do
       TestClass.virtual_attribute :child_col1, :integer, :through => :ref2, :source => :col1
       TestClass.create(:ref2 => child)
-      expect { TestClass.select(:id, :child_col1).to_a }.to_not raise_error
+      expect { TestClass.select(:id, :child_col1).to_a }.not_to raise_error
     end
   end
 
@@ -134,7 +134,7 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualDelegates, :with_test_cla
     it "properly generates sub select" do
       TestClass.virtual_attribute :child_col1, :integer, :through => :ref2, :source => :col1
       TestClass.create(:ref2 => child)
-      expect { TestClass.select(:id, :child_col1).to_a }.to_not raise_error
+      expect { TestClass.select(:id, :child_col1).to_a }.not_to raise_error
     end
   end
 

--- a/spec/virtual_includes_spec.rb
+++ b/spec/virtual_includes_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
     it "preloads through polymorphic (polymorphic => virtual_attribute)" do
       books = Book.includes(:author_or_bookmark => :total_books).load
-      expect { expect(books.map { |b| b.author_or_bookmark.total_books }).to eq([3, 3, 3]) }.to_not make_database_queries
+      expect { expect(books.map { |b| b.author_or_bookmark.total_books }).to eq([3, 3, 3]) }.not_to make_database_queries
     end
 
     it "preloads through virtual_has_many (virtual_has_many => virtual_attribute)" do
       authors = Author.includes(:named_books => :author_name).load
       expect do
         expect(authors.first.named_books.map(&:author_name)).to eq([author_name] * 3)
-      end.to_not make_database_queries
+      end.not_to make_database_queries
     end
 
     it "preloads habtm" do
@@ -293,13 +293,13 @@ RSpec.describe ActiveRecord::VirtualAttributes::VirtualIncludes do
 
     it "preloads through association" do
       books = preloaded(Book.all.to_a, :author => :total_books)
-      expect { books.map { |book| book.author.total_books } }.to_not make_database_queries
+      expect { books.map { |book| book.author.total_books } }.not_to make_database_queries
     end
 
     it "doesn't preloads through polymorphic" do ##
       # not sure what is expected to happen for preloading a column (that is not standard rails) use select instead
       a = preloaded(Book.all.to_a, :author_or_bookmark => :total_books)
-      expect { a.map { |book| book.author_or_bookmark.total_books } }.to_not make_database_queries
+      expect { a.map { |book| book.author_or_bookmark.total_books } }.not_to make_database_queries
     end
 
     it "uses included associations" do

--- a/spec/virtual_total_spec.rb
+++ b/spec/virtual_total_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
         expect do
           expect(author.total_books).to eq(2)
-        end.to_not make_database_queries
+        end.not_to make_database_queries
       end
 
       it "calculates totals with preloaded associations with no associated records" do
@@ -88,7 +88,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
         expect do
           expect(author.total_books).to eq(0)
-        end.to_not make_database_queries
+        end.not_to make_database_queries
       end
 
       it "calculates totals with attribute" do
@@ -107,7 +107,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
         query = Author.select(:id, :total_books).load
         expect do
           expect(query.map(&:total_books)).to match_array([0])
-        end.to_not make_database_queries
+        end.not_to make_database_queries
       end
     end
 
@@ -421,7 +421,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
         expect do
           expect(query).to match_array([auth1, auth2])
           expect(query.map(&:total_ordered_books)).to match_array([0, 2])
-        end.to_not make_database_queries
+        end.not_to make_database_queries
       end
 
       def model_with_children(count)
@@ -465,7 +465,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
           expect do
             expect(authors.map(&:sum_recently_published_books_rating)).to eq([6, 5, nil, nil])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates sum from attribute" do
@@ -473,7 +473,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.select(:id, :sum_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates sum from attribute (and preloaded association)" do
@@ -481,7 +481,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.includes(:recently_published_books).select(:id, :sum_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:sum_recently_published_books_rating)).to eq([6, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "orders by values with a nil (having the nil (defaulted to 0) first" do
@@ -505,7 +505,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
           expect do
             expect(authors.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates avg from attribute" do
@@ -513,7 +513,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.select(:id, :average_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates avg from attribute (and preloaded association)" do
@@ -521,7 +521,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.includes(:recently_published_books).select(:id, :average_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:average_recently_published_books_rating)).to eq([3, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
       end
 
@@ -540,7 +540,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
           expect do
             expect(authors.map(&:maximum_recently_published_books_rating)).to eq([4, 5, nil, nil])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates max from attribute" do
@@ -548,7 +548,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.select(:id, :maximum_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:maximum_recently_published_books_rating)).to eq([4, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates max from attribute (and preloaded association)" do
@@ -556,7 +556,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.includes(:recently_published_books).select(:id, :maximum_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:maximum_recently_published_books_rating)).to eq([4, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
       end
 
@@ -575,7 +575,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
 
           expect do
             expect(authors.map(&:minimum_recently_published_books_rating)).to eq([2, 5, nil, nil])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates min from attribute" do
@@ -583,7 +583,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.select(:id, :minimum_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:minimum_recently_published_books_rating)).to eq([2, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
 
         it "calculates min from attribute (and preloaded association)" do
@@ -591,7 +591,7 @@ RSpec.describe VirtualAttributes::VirtualTotal do
           query = Author.includes(:recently_published_books).select(:id, :minimum_recently_published_books_rating).order(:id).load
           expect do
             expect(query.map(&:minimum_recently_published_books_rating)).to eq([2, 5, 0, 0])
-          end.to_not make_database_queries
+          end.not_to make_database_queries
         end
       end
 


### PR DESCRIPTION
- convert `expect().not_to verb` => `expect().not to verb` to keep the `to verb` together (i.e.: not split the infinitive)
- fix rubocops around spacing in blocks
- For :through declarations referencing unknown delegations, give a more descriptive error message
- remove duplicate bogus :through detection for virtual_delegates


currently mia: miq_bot and codeclimate.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
