### PR TITLE
Make the virtual_delegate deprecation warning less noisy

### DIFF
--- a/lib/active_record/virtual_attributes/virtual_delegates.rb
+++ b/lib/active_record/virtual_attributes/virtual_delegates.rb
@@ -16,8 +16,6 @@ module ActiveRecord
 
         def virtual_delegate(*methods, to:, type:, prefix: nil, allow_nil: nil, default: nil, uses: nil, **options) # rubocop:disable Naming/MethodParameterName
           src_loc = caller_locations
-          ActiveRecord::VirtualAttributes.deprecator.warn("Convert virtual_delegate to virtual_attribute", src_loc)
-
           to = to.to_s
           if to.include?(".") && (methods.size > 1 || prefix)
             raise ArgumentError, 'Delegation only supports specifying a target method name when defining a single virtual method with no prefix'
@@ -35,7 +33,7 @@ module ActiveRecord
             # NOTE: delete_blank will remove a default of []. we only want to remove nils
             va_params = options.merge(:uses => uses, :through => to, :source => method, :default => default).delete_if { |_n, v| v.nil? }
 
-            ActiveRecord::VirtualAttributes.deprecator.warn("suggestion: #{name}.virtual_attribute #{method_name.inspect}, #{type.inspect}, #{va_params.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(", ")}", src_loc)
+            ActiveRecord::VirtualAttributes.deprecator.warn("virtual_delegate is deprecated in favor of virtual_attribute. Change to: #{name}.virtual_attribute #{method_name.inspect}, #{type.inspect}, #{va_params.map { |k, v| "#{k.inspect} => #{v.inspect}" }.join(", ")}", src_loc)
             virtual_attribute(method_name, type, **va_params)
           end
         end


### PR DESCRIPTION
We can condense the two lines into one without losing much information.

Before:

```
DEPRECATION WARNING: Convert virtual_delegate to virtual_attribute (called from <class:MiqServer> at ../manageiq/app/models/miq_server.rb:33)
DEPRECATION WARNING: suggestion: MiqServer.virtual_attribute :zone_description, :string, :through => :zone, :source => :description (called from <class:MiqServer> at ../manageiq/app/models/miq_server.rb:33)
```

After:

```
DEPRECATION WARNING: virtual_delegate is deprecated in favor of virtual_attribute. Change to: MiqServer.virtual_attribute :zone_description, :string, :through => :zone, :source => :description (called from <class:MiqServer> at ../manageiq/app/models/miq_server.rb:33)
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
