### PR TITLE
Migrate to mysql trilogy drivers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,5 +65,5 @@ jobs:
       run: bundle exec rake
     - name: Run MySQL tests
       env:
-        DB: mysql2
+        DB: mysql
       run: bundle exec rake

--- a/activerecord-virtual_attributes.gemspec
+++ b/activerecord-virtual_attributes.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "db-query-matchers"
   spec.add_development_dependency "manageiq-style"
 
-  spec.add_development_dependency "mysql2"
+  spec.add_development_dependency "trilogy"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/db/database.yml
+++ b/spec/db/database.yml
@@ -14,11 +14,12 @@ postgresql:
   username: postgres
   wait_timeout: 5
 
-mysql2:
-  adapter: mysql2
+trilogy:
+  adapter: trilogy
   database: virtual_attributes
   encoding: utf8
   host: 127.0.0.1
   pool: 3
   username: root
+  password: <%= ENV["MYSQL_PWD"] %>
   wait_timeout: 5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
     # truncate at startup
     DatabaseCleaner.clean_with :truncation
     # transaction between examples (mysql requires truncation)
-    DatabaseCleaner.strategy = Database.adapter.include?("mysql") ? :truncation : :transaction
+    DatabaseCleaner.strategy = Database.mysql? ? :truncation : :transaction
   end
 
   config.around(:each) do |example|

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -3,16 +3,20 @@ require "active_record"
 require "erb"
 
 class Database
-  VALID_ADAPTERS = %w[sqlite3 postgresql mysql2].freeze
+  VALID_ADAPTERS = %w[sqlite3 postgresql trilogy].freeze
 
   def self.adapter
     case ENV.fetch('DB', "sqlite")
-    when "sqlite", "sqlite3" then ENV['DB'] = "sqlite3"
-    when "pg", "postgresql"  then ENV['DB'] = "postgresql"
-    when "mysql", "mysql2"   then ENV['DB'] = "mysql2"
+    when "sqlite", "sqlite3"          then ENV["DB"] = "sqlite3"
+    when "pg", "postgresql"           then ENV["DB"] = "postgresql"
+    when "mysql", "mysql2", "trilogy" then ENV["DB"] = "trilogy"
     else
       raise "ENV['DB'] value invalid, must be one of: #{VALID_ADAPTERS.join(", ")}"
     end
+  end
+
+  def self.mysql?
+    adapter == "trilogy" || adapter == "mysql2"
   end
 
   attr_accessor :dirname


### PR DESCRIPTION
# Background

The `mysql2` gem needs `libmysql` to install. This is a pain to install for many users.
GitHub and others have moved on to `trilogy` as their MySQL driver.

# Goal

- Support the `trilogy` driver.
- Use `trilogy` for tests.

# Thoughts

MySql used to use `mysql` gem, then `mysql2` gem, now it is `trilogy`. Seems like just the way the drivers for MySql work. 
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
